### PR TITLE
[WIP] wallet_switchEthereumChain request

### DIFF
--- a/provider-worker/src/methods.ts
+++ b/provider-worker/src/methods.ts
@@ -25,9 +25,10 @@ const chainId: Handler = (_req, res, _next, end) => {
 };
 
 const switchChain: Handler = (req, res, next, end) => {
-  // TODO:
-  // const requestedChainId = req.params![0].chainId;
+  const requestedChainId = Number(req.params![0].chainId);
+  useStore.getState().switchToChain(Number(requestedChainId));
 
+  res.result = null;
   console.log("[req]", req);
   end();
 };

--- a/state/src/settings/index.tsx
+++ b/state/src/settings/index.tsx
@@ -5,12 +5,18 @@ import {
   type NetworkFullSchema,
 } from "./network";
 import { type WalletFullSchema, WalletSettings, WalletSchema } from "./wallet";
+import { type Stream } from "stream";
 
 export interface SettingsSection<Schema, Derived> {
   schema: z.ZodSchema<Schema>;
 
   defaults: () => Schema & Derived;
 }
+
+export type SettingsOpts = {
+  get: () => SettingsFullSchema;
+  stream?: Stream;
+};
 
 export type SettingsSchema = {
   wallet: WalletSchema;

--- a/state/src/settings/utils.tsx
+++ b/state/src/settings/utils.tsx
@@ -1,0 +1,10 @@
+import { type Stream } from "stream";
+import { SettingsFullSchema } from ".";
+
+export type Opts = {
+  get: () => SettingsFullSchema;
+
+  // TODO: this should be a mandatory field
+  // but I'm not sure how to make it available for the `switchToChain` method
+  stream?: Stream;
+};

--- a/state/src/settings/wallet.tsx
+++ b/state/src/settings/wallet.tsx
@@ -4,6 +4,7 @@ import { Address, deriveAddress } from "../addresses";
 import { ethers } from "ethers";
 import { SettingsFullSchema } from "./index";
 import { type Stream } from "stream";
+import { Opts } from "./utils";
 
 const schema = z.object({
   mnemonic: z
@@ -22,11 +23,6 @@ interface ExtraFields {
 }
 
 export type WalletFullSchema = WalletSchema & ExtraFields;
-
-type Opts = {
-  get: () => SettingsFullSchema;
-  stream: Stream;
-};
 
 export const WalletSettings = {
   schema,
@@ -58,7 +54,7 @@ export const WalletSettings = {
 
     const addressChanged = address != oldSettings.wallet.address;
 
-    if (addressChanged) {
+    if (addressChanged && !!stream) {
       stream.write({
         type: "broadcast",
         payload: {

--- a/state/src/store.ts
+++ b/state/src/store.ts
@@ -24,6 +24,7 @@ interface Setters {
   setNetworks: (settings: NetworkSchema["networks"], stream: Stream) => void;
   setCurrentNetwork: (index: number, stream: Stream) => void;
   getProviderState: () => ProviderState;
+  switchToChain: (chainId: number) => void;
 }
 
 type Store = SettingsFullSchema & Setters;
@@ -74,6 +75,17 @@ function generateSetters(
         networkVersion: currentNetwork.name,
         accounts: [wallet.address],
       };
+    },
+
+    // TODO: this is called from the background
+    // all others are currently called from expanded.tsx
+    // this means storage is being updated, but not the in-memory copy of each process
+    // It also means we don't actually broadcast the `chainChanged` event, so
+    // even the page that requested this is not updated
+    // Need to figure out a way to keep storage centralized on the same process
+    switchToChain: (chainId: number) => {
+      const network = NetworkSettings.switchToChain(chainId, { get });
+      set({ network });
     },
   };
 }


### PR DESCRIPTION
I hate this PR

it introduces a needed features: ability for a webpage to request a switch to a specific network

There are two problems caused by this:
1. some pages will automatically attempt this switch. Since we have no confirmation popup, this can cause two separate pages to enter a livelock where both are constantly switching to the chain they want, ad eternum. This can be solved with some confirmation tool, that can for now exist on the expanded page rather than a popup (I'll open an issue for this)

2. the other, more complex one, is that our storage is broken. So far, `useStore` has been used inside the expanded page. so in the context of an extension page, and not the service worker. But to handle this new request, the background worker is the one requesting a store update. which we means we're using a separate instance of the zustand store. It all goes down to `browser.storage.local` so it ends up stored correctly, but because we're updating in the background process, hooks on the expanded page are not triggered for the update. It also means we don't have the `stream` object which we used to broadcast this change

So it's clear from point 2 that we need to change how storage is made.
It seems the way to go is for all storage to exist on the background (since that's the source of truth anyway), and have the extension pages communicate with it rather than using their own zustand hooks

This likely means dropping zustand entirely and build our own hooks. or create a react-query wrapper around whatevr communication mechanism we end up using