### PR TITLE
Fix: multiple tabs being open when live reloading enabled

### DIFF
--- a/ui/roots.tsx
+++ b/ui/roots.tsx
@@ -1,4 +1,5 @@
 import PortStream from "extension-port-stream";
+import { useEffect } from "react";
 import { Route, Router } from "wouter";
 
 import {
@@ -37,7 +38,9 @@ export function Expanded({ stream }: Props) {
 
 export function Popup({ stream }: Props) {
   // let's skip the popup for now (or even forever?)
-  expand();
+  useEffect(() => {
+    expand();
+  }, []);
 
   return (
     <ExtensionContext.Provider value={{ stream: stream }}>


### PR DESCRIPTION
@mirhamasala I'm gonna take a guess that this is why #37 was happening
probably since you use `yarn dev`, which includes live-reloading logic that I don't have, it was triggering multiple renders of the Popup component, each of which would expand a new tab