### PR TITLE
Truncating only txs for the current chain

### DIFF
--- a/tauri/src/context/block_listener.rs
+++ b/tauri/src/context/block_listener.rs
@@ -143,9 +143,7 @@ async fn watch(
             Ok(res) = client.request::<_, U64>("eth_blockNumber", ()) => res
         };
 
-        block_snd
-            .send(Msg::Reset)
-            .map_err(|_| Error::Watcher)?;
+        block_snd.send(Msg::Reset).map_err(|_| Error::Watcher)?;
 
         let provider: Provider<Ws> = Provider::<Ws>::connect(&ws_url)
             .await?
@@ -167,9 +165,7 @@ async fn watch(
         let past_range = fork_block..=block_number.low_u64();
         for b in past_range.into_iter() {
             if let Some(b) = provider.get_block_with_txs(b).await? {
-                block_snd
-                    .send(Msg::Block(b))
-                    .map_err(|_| Error::Watcher)?
+                block_snd.send(Msg::Block(b)).map_err(|_| Error::Watcher)?
             }
         }
 
@@ -199,7 +195,7 @@ async fn process(mut block_rcv: mpsc::UnboundedReceiver<Msg>, chain_id: u32, db:
     // TODO: broadcast this info to the frontend, so it can refresh right away
     while let Some(msg) = block_rcv.recv().await {
         match msg {
-            Msg::Reset => db.truncate_transactions().await?,
+            Msg::Reset => db.truncate_transactions(chain_id).await?,
             Msg::Block(block) => db.save_transactions(chain_id, block.transactions).await?,
         }
     }

--- a/tauri/src/store/transactions.rs
+++ b/tauri/src/store/transactions.rs
@@ -8,7 +8,7 @@ use crate::error::Result;
 
 #[async_trait]
 pub trait TransactionStore {
-    async fn truncate_transactions(&self) -> Result<()>;
+    async fn truncate_transactions(&self, chain_id: u32) -> Result<()>;
     async fn save_transactions(&self, chain_id: u32, tx: Vec<Transaction>) -> Result<()>;
 
     // TODO: should maybe return Vec<H256> here
@@ -53,8 +53,9 @@ impl TransactionStore for DB {
         Ok(res)
     }
 
-    async fn truncate_transactions(&self) -> Result<()> {
-        sqlx::query("DELETE FROM transactions")
+    async fn truncate_transactions(&self, chain_id: u32) -> Result<()> {
+        sqlx::query("DELETE FROM transactions WHERE chain_id = ?")
+            .bind(chain_id)
             .execute(self.pool())
             .await?;
 


### PR DESCRIPTION
When reseting anvil, we were previously truncating the entire transactions table. Instead we should just truncate the relevant chain_id