### PR TITLE
Using rust stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           override: true
           components: rustfmt, clippy
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          override: true
 
       - name: rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,7 @@ jobs:
       - name: setup rust
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           override: true
 
       - name: rust cache

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -1,6 +1,7 @@
-use std::{path::PathBuf, sync::OnceLock};
+use std::path::PathBuf;
 
 use log::debug;
+use once_cell::sync::OnceCell;
 use serde::Serialize;
 use tauri::{
     AppHandle, Builder, CustomMenuItem, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu,
@@ -32,8 +33,8 @@ impl IronEvent {
     }
 }
 
-pub static DB_PATH: OnceLock<PathBuf> = OnceLock::new();
-pub static SETTINGS_PATH: OnceLock<PathBuf> = OnceLock::new();
+pub static DB_PATH: OnceCell<PathBuf> = OnceCell::new();
+pub static SETTINGS_PATH: OnceCell<PathBuf> = OnceCell::new();
 
 impl IronApp {
     pub fn build() -> Self {

--- a/tauri/src/main.rs
+++ b/tauri/src/main.rs
@@ -1,6 +1,5 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-#![feature(once_cell)]
 
 mod app;
 mod commands;


### PR DESCRIPTION
We don't actually need nightly right now (just need to use the once_cell crate instead of the nightly-only std feature)
and this should greatly improve build caching on CI