### PR TITLE
Ability to automatically open dev tools

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -11,7 +11,7 @@ build:
 
 dev:
   rm -rf target/debug/db.*
-  yarn run tauri dev
+  yarn run tauri dev --features "debug"
 
 lint:
   cargo fmt --all -- --check

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -41,3 +41,4 @@ default = []
 # this feature is used for production builds or when `devPath` points to the filesystem
 # DO NOT REMOVE!!
 custom-protocol = ["tauri/custom-protocol"]
+debug = ["tauri/devtools"]

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -61,6 +61,12 @@ impl IronApp {
                     event_listener(handle, rcv).await;
                 });
 
+                #[cfg(feature = "debug")]
+                if std::env::var("IRON_OPEN_DEVTOOLS").is_ok() {
+                    let window = app.get_window("main").unwrap();
+                    window.open_devtools();
+                }
+
                 Ok(())
             })
             .system_tray(tray)


### PR DESCRIPTION
Setting `IRON_OPEN_DEVTOOLS=1` and `--features debug` will automatically open devtools on startup