### PR TITLE
improving yarn lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,13 @@ module.exports = {
   ],
   parser: "@typescript-eslint/parser",
   plugins: ["react", "@typescript-eslint"],
-  ignorePatterns: ["**/*.generated.ts", "node_modules/*", "dist/*"],
+  ignorePatterns: [
+    "**/*.generated.ts",
+    "node_modules/*",
+    "extension/dist/*",
+    "gui/dist/*",
+    "extension/provider-inpage/*",
+  ],
   settings: {
     react: {
       version: "detect",

--- a/extension/global.d.ts
+++ b/extension/global.d.ts
@@ -1,5 +1,0 @@
-declare global {
-  interface Window {
-    MyNamespace: any;
-  }
-}

--- a/gui/src/components/Settings/Wallet.tsx
+++ b/gui/src/components/Settings/Wallet.tsx
@@ -2,7 +2,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { invoke } from "@tauri-apps/api/tauri";
 import { useCallback, useEffect, useState } from "react";
 import { FieldValues, useForm } from "react-hook-form";
-import truncateEthAddress from "truncate-eth-address";
 
 import { useInvoke } from "../../hooks/tauri";
 import { Address, Wallet, walletSchema } from "../../types";

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "gui:build": "yarn workspace @iron/gui build",
     "extension:dev": "yarn workspace @iron/extension dev",
     "extension:build": "yarn workspace @iron/extension build",
-    "lint": "eslint .",
+    "lint": "yarn lint:eslint && yarn lint:tsc",
+    "lint:eslint": "eslint .",
+    "lint:tsc": "tsc --noEmit",
     "setup": "yarn install && yarn extension:build"
   },
   "workspaces": [


### PR DESCRIPTION
adding `tsc --noEmit` to the CI, since the release workflow keeps failling due to uncaught typescript problems