### PR TITLE
Fixing balances

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: publish release
-        run: gh release edit ${{ needs.create.outputs.release_id }} --draft=false
+        run: gh release edit ${{ needs.create.outputs.tag }} --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/migrations/04_create_balances.sql
+++ b/migrations/04_create_balances.sql
@@ -2,7 +2,7 @@ CREATE TABLE balances (
   contract VARCHAR COLLATE NOCASE,
   owner VARCHAR COLLATE NOCASE,
   chain_id INTEGER NOT NULL,
-  balance BIG INT NOT NULL,
+  balance TEXT NOT NULL,
   PRIMARY KEY (contract, owner, chain_id)
 );
 

--- a/tauri/src/commands.rs
+++ b/tauri/src/commands.rs
@@ -1,5 +1,4 @@
 use ethers::types::{Address, U256};
-use log::error;
 
 use crate::context::{Context, Network, Wallet};
 use crate::store::events::EventsStore;


### PR DESCRIPTION
Fixes balances accounting, since sqlite cannot handle integers above 64-bits, which means `u256` arithmetic is completely out of the question

this is now doing the unfortunate thing of reading the current value -> computing the new balance in Rust, and updating in a separate query

not safe against race conditions, but will have to do for a bit