### PR TITLE
Increase the starting window's width

### DIFF
--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -48,7 +48,7 @@
         "fullscreen": false,
         "resizable": true,
         "title": "iron",
-        "width": 450,
+        "width": 1000,
         "height": 600
       }
     ]


### PR DESCRIPTION
So it doesn't look like this: 

<img width="508" alt="Screenshot 2023-05-11 at 23 42 07" src="https://github.com/iron-wallet/iron/assets/934580/7b4bebf5-ca28-47aa-9317-d162e1bddaab">
