### PR TITLE
Solving clippy lints

### DIFF
--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -1,14 +1,13 @@
 import { Stack, Typography } from "@mui/material";
-import { listen } from "@tauri-apps/api/event";
 import { erc20ABI } from "@wagmi/core";
 import { BigNumber } from "ethers";
 import { formatUnits } from "ethers/lib/utils.js";
 import React from "react";
-import { useEffect } from "react";
 import { useBalance, useContractRead } from "wagmi";
 
 import { useAccount } from "../hooks";
 import { useInvoke } from "../hooks/tauri";
+import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
 import { Address } from "../types";
 import Panel from "./Panel";
 
@@ -19,15 +18,7 @@ export function Balances() {
     { address }
   );
 
-  useEffect(() => {
-    const unlisten = listen("refresh-transactions", () => {
-      mutate();
-    });
-
-    return () => {
-      unlisten.then((cb) => cb());
-    };
-  }, [mutate]);
+  useRefreshTransactions(mutate);
 
   return (
     <Panel>

--- a/gui/src/components/Contracts.tsx
+++ b/gui/src/components/Contracts.tsx
@@ -1,24 +1,15 @@
 import { List, ListItem, ListItemText } from "@mui/material";
-import { listen } from "@tauri-apps/api/event";
 import React from "react";
-import { useEffect } from "react";
 
 import { useInvoke } from "../hooks/tauri";
+import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
 import { Address } from "../types";
 import Panel from "./Panel";
 
 export function Contracts() {
   const { data: addresses, mutate } = useInvoke<Address[]>("get_contracts");
 
-  useEffect(() => {
-    const unlisten = listen("refresh-transactions", () => {
-      mutate();
-    });
-
-    return () => {
-      unlisten.then((cb) => cb());
-    };
-  }, [mutate]);
+  useRefreshTransactions(mutate);
 
   return (
     <Panel>

--- a/gui/src/hooks/useRefreshConnections.ts
+++ b/gui/src/hooks/useRefreshConnections.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 export function useRefreshConnections(callback: () => unknown) {
   useEffect(() => {
-    const unlisten = listen("refresh-connections", () => {
+    const unlisten = listen("connections-updated", () => {
       callback();
     });
 

--- a/gui/src/hooks/useRefreshNetwork.ts
+++ b/gui/src/hooks/useRefreshNetwork.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 export function useRefreshNetwork(callback: () => unknown) {
   useEffect(() => {
-    const unlisten = listen("refresh-network", () => {
+    const unlisten = listen("network-changed", () => {
       callback();
     });
 

--- a/gui/src/hooks/useRefreshTransactions.ts
+++ b/gui/src/hooks/useRefreshTransactions.ts
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 export function useRefreshTransactions(callback: () => unknown) {
   useEffect(() => {
-    const unlisten = listen("refresh-transactions", () => {
+    const unlisten = listen("txs-updated", () => {
       callback();
     });
 

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -17,17 +17,17 @@ pub struct IronApp {
 
 #[derive(Debug, Serialize)]
 pub enum IronEvent {
-    RefreshNetwork,
-    RefreshTransactions,
-    RefreshConnections,
+    NetworkChanged,
+    TxsUpdated,
+    ConnectionsUpdated,
 }
 
 impl IronEvent {
     fn label(&self) -> &str {
         match self {
-            Self::RefreshNetwork => "refresh-network",
-            Self::RefreshTransactions => "refresh-transactions",
-            Self::RefreshConnections => "refresh-connections",
+            Self::NetworkChanged => "network-changed",
+            Self::TxsUpdated => "txs-updated",
+            Self::ConnectionsUpdated => "connections-updated",
         }
     }
 }

--- a/tauri/src/context/block_listener.rs
+++ b/tauri/src/context/block_listener.rs
@@ -219,7 +219,7 @@ async fn process(
         // don't emit events until we're catching up
         // otherwise we spam too much during that phase
         if caught_up {
-            window_snd.send(IronEvent::RefreshTransactions)?;
+            window_snd.send(IronEvent::TxsUpdated)?;
         }
     }
 

--- a/tauri/src/context/inner.rs
+++ b/tauri/src/context/inner.rs
@@ -104,7 +104,7 @@ impl ContextInner {
         self.window_snd
             .as_ref()
             .unwrap()
-            .send(IronEvent::RefreshConnections)
+            .send(IronEvent::ConnectionsUpdated)
             .unwrap();
     }
 
@@ -114,7 +114,7 @@ impl ContextInner {
         self.window_snd
             .as_ref()
             .unwrap()
-            .send(IronEvent::RefreshConnections)
+            .send(IronEvent::ConnectionsUpdated)
             .unwrap();
     }
 
@@ -168,7 +168,7 @@ impl ContextInner {
             self.window_snd
                 .as_ref()
                 .unwrap()
-                .send(IronEvent::RefreshNetwork)?
+                .send(IronEvent::NetworkChanged)?
         }
 
         self.save()?;

--- a/tauri/src/rpc.rs
+++ b/tauri/src/rpc.rs
@@ -45,7 +45,7 @@ fn ethers_to_jsonrpc_error(e: ProviderError) -> jsonrpc_core::Error {
                     data: e.data.clone(),
                     message: e.message.clone(),
                 }
-            } else if let Some(e) = e.as_serde_error() {
+            } else if e.as_serde_error().is_some() {
                 jsonrpc_core::Error::invalid_request()
             } else {
                 jsonrpc_core::Error::internal_error()


### PR DESCRIPTION
One of the lints was about all events in the enum being called `Refresh....`, so I renamed them for a bit more clarity

I also ended up finding the `useRefreshTransactions` hook and used it in a couple of places where the original useEffect still existed