### PR TITLE
Initial support for keyboard navigation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,14 @@ module.exports = {
   rules: {
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+        caughtErrorsIgnorePattern: "^_",
+      },
+    ],
   },
 };

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,7 +3371,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
@@ -4106,7 +4106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -12,6 +12,7 @@ import { Route, Router } from "wouter";
 
 import { HomePage } from "./components/HomePage";
 import { Navbar } from "./components/Navbar";
+import { NestedRoutes } from "./components/NestedRoutes";
 import { WagmiWrapper } from "./components/WagmiWrapper";
 import { useHashLocation } from "./hooks/hashLocation";
 
@@ -47,9 +48,11 @@ export default function App() {
       <CssBaseline>
         <QueryClientProvider client={queryClient}>
           <WagmiWrapper>
-            <Router hook={useHashLocation}>
+            <Router>
               <Navbar />
-              <Route path="/" component={HomePage} />
+              <NestedRoutes base="/">
+                <HomePage />
+              </NestedRoutes>
             </Router>
           </WagmiWrapper>
         </QueryClientProvider>

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -1,24 +1,56 @@
 import { Container, Paper, Tab, Tabs } from "@mui/material";
-import React from "react";
-import { useState } from "react";
+import { appWindow } from "@tauri-apps/api/window";
+import { findIndex, parseInt, range, toString } from "lodash";
+import React, { useEffect } from "react";
+import { Link, Route, Switch, useLocation, useRoute } from "wouter";
 
+import { useKeyPress } from "../hooks/useKeyPress";
 import { Balances } from "./Balances";
 import { Connections } from "./Connections";
 import { Contracts } from "./Contracts";
 import { Details } from "./Details";
-import { TabPanel } from "./TabPanel";
 import { Txs } from "./Txs";
 
 const tabs = [
-  { name: "Details", component: Details },
-  { name: "Transactions", component: Txs },
-  { name: "Balances", component: Balances },
-  { name: "Contracts", component: Contracts },
-  { name: "Connections", component: Connections },
+  { path: "details", name: "Details", component: Details },
+  { path: "transactions", name: "Transactions", component: Txs },
+  { path: "balances", name: "Balances", component: Balances },
+  { path: "contracts", name: "Contracts", component: Contracts },
+  { path: "connections", name: "Connections", component: Connections },
 ];
 
 export function HomePage() {
-  const [currentTab, setCurrentTab] = useState(0);
+  const [_match, params] = useRoute(":path");
+  const [_location, setLocation] = useLocation();
+
+  useEffect(() => {
+    const unlisten = appWindow.listen(
+      "go",
+      ({ payload }: { payload: string }) => {
+        setLocation(payload);
+      }
+    );
+
+    return () => {
+      unlisten.then((cb) => cb());
+    };
+  }, [setLocation]);
+
+  const handleKeyboardNavigation = (event: KeyboardEvent) => {
+    setLocation(tabs[parseInt(event.key) - 1].path);
+  };
+
+  useKeyPress(
+    range(1, tabs.length + 1).map(toString),
+    { meta: true },
+    handleKeyboardNavigation
+  );
+
+  useKeyPress(
+    range(1, tabs.length + 1).map(toString),
+    { ctrl: true },
+    handleKeyboardNavigation
+  );
 
   return (
     <Container maxWidth="md">
@@ -26,18 +58,29 @@ export function HomePage() {
         <Tabs
           variant="fullWidth"
           sx={{ mb: 2 }}
-          value={currentTab}
-          onChange={(_e, newTab) => setCurrentTab(newTab)}
+          value={Math.max(findIndex(tabs, { path: params?.path }), 0)}
         >
           {tabs.map((tab) => (
-            <Tab key={tab.name} label={tab.name} />
+            <Tab
+              LinkComponent={Link}
+              href={tab.path}
+              key={tab.name}
+              label={tab.name}
+            />
           ))}
         </Tabs>
-        {tabs.map((tab, index) => (
-          <TabPanel index={index} key={tab.name} value={currentTab}>
-            <tab.component />
-          </TabPanel>
-        ))}
+        <div role="tabpanel">
+          <Switch>
+            {tabs.map((tab) => (
+              <Route key={tab.path || "/"} path={tab.path}>
+                <tab.component />
+              </Route>
+            ))}
+            <Route>
+              <Details />
+            </Route>
+          </Switch>
+        </div>
       </Paper>
     </Container>
   );

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -5,6 +5,7 @@ import React, { useEffect } from "react";
 import { Link, Route, Switch, useLocation, useRoute } from "wouter";
 
 import { useKeyPress } from "../hooks/useKeyPress";
+import { useMenuAction } from "../hooks/useMenuAction";
 import { Balances } from "./Balances";
 import { Connections } from "./Connections";
 import { Contracts } from "./Contracts";
@@ -23,18 +24,7 @@ export function HomePage() {
   const [_match, params] = useRoute(":path");
   const [_location, setLocation] = useLocation();
 
-  useEffect(() => {
-    const unlisten = appWindow.listen(
-      "go",
-      ({ payload }: { payload: string }) => {
-        setLocation(payload);
-      }
-    );
-
-    return () => {
-      unlisten.then((cb) => cb());
-    };
-  }, [setLocation]);
+  useMenuAction((payload) => setLocation(payload));
 
   const handleKeyboardNavigation = (event: KeyboardEvent) => {
     setLocation(tabs[parseInt(event.key) - 1].path);

--- a/gui/src/components/NestedRoutes.tsx
+++ b/gui/src/components/NestedRoutes.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { ReactNode } from "react";
+import { Router, useLocation, useRouter } from "wouter";
+
+export function NestedRoutes({
+  children,
+  base,
+}: {
+  children: ReactNode;
+  base: string;
+}) {
+  const router = useRouter();
+  const [parentLocation] = useLocation();
+
+  const nestedBase = `${router.base}${base}`;
+
+  if (!parentLocation.startsWith(nestedBase)) return null;
+
+  return (
+    <Router base={nestedBase} key={nestedBase}>
+      {children}
+    </Router>
+  );
+}

--- a/gui/src/components/Panel.tsx
+++ b/gui/src/components/Panel.tsx
@@ -2,5 +2,5 @@ import { Box } from "@mui/material";
 import React, { ReactNode } from "react";
 
 export default function Panel({ children }: { children: ReactNode }) {
-  return <Box sx={{ p: 4 }}>{children}</Box>;
+  return <Box sx={{ pb: 4, pt: 2, px: 4, minHeight: 300 }}>{children}</Box>;
 }

--- a/gui/src/components/QuickAccountSelect.tsx
+++ b/gui/src/components/QuickAccountSelect.tsx
@@ -47,6 +47,7 @@ export function QuickAccountSelect() {
 
   return (
     <Select
+      size="small"
       renderValue={(value: number) =>
         addresses[value] && truncateEthAddress(addresses[value])
       }

--- a/gui/src/components/QuickNetworkSelect.tsx
+++ b/gui/src/components/QuickNetworkSelect.tsx
@@ -24,7 +24,7 @@ export function QuickNetworkSelect() {
   if (!networks || !current) return <>Loading</>;
 
   return (
-    <Select onChange={handleChange} value={current.name} label="">
+    <Select size="small" onChange={handleChange} value={current.name} label="">
       {networks.map((network) => (
         <MenuItem value={network.name} key={network.name}>
           {network.name}

--- a/gui/src/hooks/useKeyPress.ts
+++ b/gui/src/hooks/useKeyPress.ts
@@ -6,13 +6,11 @@ export const useKeyPress = (
   callback: (event: KeyboardEvent) => unknown,
   node = null
 ) => {
-  // implement the callback ref pattern
   const callbackRef = useRef(callback);
   useLayoutEffect(() => {
     callbackRef.current = callback;
   });
 
-  // handle what happens on key press
   const handleKeyPress = useCallback(
     (event: KeyboardEvent) => {
       const { metaKey, ctrlKey, altKey, shiftKey } = event;
@@ -31,12 +29,9 @@ export const useKeyPress = (
   );
 
   useEffect(() => {
-    // target is either the provided node or the document
     const targetNode = node ?? document;
-    // attach the event listener
     targetNode && targetNode.addEventListener("keydown", handleKeyPress);
 
-    // remove the event listener
     return () =>
       targetNode && targetNode.removeEventListener("keydown", handleKeyPress);
   }, [handleKeyPress, node]);

--- a/gui/src/hooks/useKeyPress.ts
+++ b/gui/src/hooks/useKeyPress.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
+
+export const useKeyPress = (
+  keys: string[],
+  modifiers: { alt?: boolean; meta?: boolean; ctrl?: boolean; shift?: boolean },
+  callback: (event: KeyboardEvent) => unknown,
+  node = null
+) => {
+  // implement the callback ref pattern
+  const callbackRef = useRef(callback);
+  useLayoutEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  // handle what happens on key press
+  const handleKeyPress = useCallback(
+    (event: KeyboardEvent) => {
+      const { metaKey, ctrlKey, altKey, shiftKey } = event;
+
+      if (
+        keys.some((key) => event.key === key) &&
+        metaKey === !!modifiers.meta &&
+        ctrlKey === !!modifiers.ctrl &&
+        altKey === !!modifiers.alt &&
+        shiftKey === !!modifiers.shift
+      ) {
+        callbackRef.current(event);
+      }
+    },
+    [keys, modifiers]
+  );
+
+  useEffect(() => {
+    // target is either the provided node or the document
+    const targetNode = node ?? document;
+    // attach the event listener
+    targetNode && targetNode.addEventListener("keydown", handleKeyPress);
+
+    // remove the event listener
+    return () =>
+      targetNode && targetNode.removeEventListener("keydown", handleKeyPress);
+  }, [handleKeyPress, node]);
+};

--- a/gui/src/hooks/useMenuAction.ts
+++ b/gui/src/hooks/useMenuAction.ts
@@ -1,0 +1,17 @@
+import { appWindow } from "@tauri-apps/api/window";
+import { useEffect } from "react";
+
+export function useMenuAction(callback: (payload: string) => unknown) {
+  useEffect(() => {
+    const unlisten = appWindow.listen(
+      "go",
+      ({ payload }: { payload: string }) => {
+        callback(payload);
+      }
+    );
+
+    return () => {
+      unlisten.then((cb) => cb());
+    };
+  }, [callback]);
+}

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -75,7 +75,6 @@ impl IronApp {
 
                 Ok(())
             })
-            .menu(menu)
             .on_window_event(on_window_event);
 
         #[cfg(not(target_os = "macos"))]
@@ -85,8 +84,12 @@ impl IronApp {
                 .on_system_tray_event(on_system_tray_event);
         }
 
+        #[cfg(not(target_os = "linux"))]
+        {
+            builder = builder.menu(menu).on_menu_event(on_menu_event)
+        }
+
         let app = builder
-            .on_menu_event(on_menu_event)
             .build(tauri::generate_context!())
             .expect("error while running tauri application");
 
@@ -114,18 +117,6 @@ impl IronApp {
     }
 
     fn build_menu() -> Menu {
-        let quit = CustomMenuItem::new("quit".to_string(), "Quit");
-        let close = CustomMenuItem::new("close".to_string(), "Close");
-        let file_submenu = Submenu::new("File", Menu::new().add_item(quit).add_item(close));
-
-        let edit_submenu = Submenu::new(
-            "Edit",
-            Menu::new()
-                .add_native_item(MenuItem::Cut)
-                .add_native_item(MenuItem::Copy)
-                .add_native_item(MenuItem::Paste),
-        );
-
         let details = CustomMenuItem::new("details".to_string(), "Details");
         let transactions = CustomMenuItem::new("transactions".to_string(), "Transactions");
         let balances = CustomMenuItem::new("balances".to_string(), "Balances");
@@ -141,12 +132,7 @@ impl IronApp {
                 .add_item(connections),
         );
 
-        Menu::os_default("Iron")
-            // .add_native_item(MenuItem::Copy)
-            // .add_item(CustomMenuItem::new("hide", "Hide"))
-            // .add_submenu(file_submenu)
-            // .add_submenu(edit_submenu)
-            .add_submenu(go_submenu)
+        Menu::os_default("Iron").add_submenu(go_submenu)
     }
 
     fn build_tray() -> tauri::SystemTray {

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -4,7 +4,7 @@ use once_cell::sync::OnceCell;
 use serde::Serialize;
 use tauri::{
     AppHandle, Builder, CustomMenuItem, GlobalWindowEvent, Manager, Menu, MenuItem, Submenu,
-    SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, WindowEvent,
+    SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem, WindowEvent, WindowMenuEvent,
 };
 use tauri_plugin_window_state::{AppHandleExt, Builder as windowStatePlugin, StateFlags};
 use tokio::sync::mpsc;
@@ -86,17 +86,7 @@ impl IronApp {
         }
 
         let app = builder
-            .on_menu_event(|event| match event.menu_item_id() {
-                "quit" => {
-                    std::process::exit(0);
-                }
-                "close" => {
-                    event.window().close().unwrap();
-                }
-                path => {
-                    event.window().emit("go", path).unwrap();
-                }
-            })
+            .on_menu_event(on_menu_event)
             .build(tauri::generate_context!())
             .expect("error while running tauri application");
 
@@ -186,6 +176,20 @@ impl IronApp {
 
     fn get_settings_file(&self) -> PathBuf {
         self.get_resource("settings.json")
+    }
+}
+
+fn on_menu_event(event: WindowMenuEvent) {
+    match event.menu_item_id() {
+        "quit" => {
+            std::process::exit(0);
+        }
+        "close" => {
+            event.window().close().unwrap();
+        }
+        path => {
+            event.window().emit("go", path).unwrap();
+        }
     }
 }
 

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -141,11 +141,11 @@ impl IronApp {
                 .add_item(connections),
         );
 
-        Menu::new()
-            .add_native_item(MenuItem::Copy)
-            .add_item(CustomMenuItem::new("hide", "Hide"))
-            .add_submenu(file_submenu)
-            .add_submenu(edit_submenu)
+        Menu::os_default("Iron")
+            // .add_native_item(MenuItem::Copy)
+            // .add_item(CustomMenuItem::new("hide", "Hide"))
+            // .add_submenu(file_submenu)
+            // .add_submenu(edit_submenu)
             .add_submenu(go_submenu)
     }
 


### PR DESCRIPTION
This change takes the first steps toward keyboard navigation:
* Use routes to change tabs. Using routes instead of a component's internal state means we can change tabs from anywhere. This logic will apply to everything.
* Create menubar items. The menubar allows people to set local or global shortcuts in the app. At least on macOS, you can easily map shortcuts to items in the menubar.
* Defining initial in-app shortcuts to change tabs. We can replace these later, this is just an initial step.