### PR TITLE
Show context menu

### DIFF
--- a/gui/src/components/ContextMenu.tsx
+++ b/gui/src/components/ContextMenu.tsx
@@ -1,0 +1,123 @@
+import { Button, Menu, MenuItem, SxProps, Tooltip } from "@mui/material";
+import { writeText } from "@tauri-apps/api/clipboard";
+import React, { MouseEvent, ReactNode, useState } from "react";
+
+import { useNetwork } from "../hooks/useNetwork";
+
+interface Props {
+  children: ReactNode;
+  sx?: SxProps;
+  label?: string;
+}
+
+const buttonSx = {
+  background: "transparent",
+  p: 0,
+  color: "inherit",
+  fontWeight: "inherit",
+  fontSize: "inherit",
+  border: 0,
+  minWidth: "inherit",
+};
+
+export function ContextMenu({ children, sx, label }: Props) {
+  const { network } = useNetwork();
+  const [copied, setCopied] = useState(false);
+  const [contextMenu, setContextMenu] = useState<{
+    target: HTMLElement;
+    mouseX: number;
+    mouseY: number;
+  } | null>(null);
+
+  const contextMenuOpen = Boolean(contextMenu?.target);
+  const tooltipDelay = copied ? 0 : contextMenuOpen ? Infinity : 1200;
+
+  const copyToClipboard = (text: string | null | undefined) => {
+    if (!text) throw new Error("Nothing to copy to clipboard");
+
+    writeText(text);
+    setCopied(true);
+    setContextMenu(null);
+  };
+
+  const onContextCopy = () =>
+    copyToClipboard(label || contextMenu?.target.textContent);
+
+  const onCopyText = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    copyToClipboard(label || event.currentTarget?.textContent);
+  };
+
+  const onCloseMenu = () => setContextMenu(null);
+
+  const onContextMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    setContextMenu(
+      contextMenu === null
+        ? {
+            target: e.currentTarget,
+            mouseX: e.clientX + 2,
+            mouseY: e.clientY - 6,
+          }
+        : null
+    );
+  };
+
+  return (
+    <>
+      <Tooltip
+        onClose={() => setTimeout(() => setCopied(false), 500)}
+        title={copied ? "Copied to clipboard" : "Copy to clipboard"}
+        arrow
+        enterDelay={tooltipDelay}
+        enterNextDelay={tooltipDelay}
+        leaveDelay={0}
+      >
+        <Button
+          disableRipple
+          disableFocusRipple
+          disableElevation
+          sx={{ ...buttonSx, ...sx }}
+          onClick={onCopyText}
+          onContextMenu={onContextMenu}
+        >
+          {children}
+        </Button>
+      </Tooltip>
+      {contextMenu?.target && (
+        <Menu
+          id="basic-menu"
+          anchorEl={contextMenu?.target}
+          open={contextMenuOpen}
+          onClose={onCloseMenu}
+          MenuListProps={{
+            "aria-labelledby": "basic-button",
+          }}
+          anchorReference="anchorPosition"
+          anchorPosition={
+            contextMenu !== null
+              ? { top: contextMenu.mouseY, left: contextMenu.mouseX }
+              : undefined
+          }
+        >
+          <MenuItem onClick={onContextCopy}>Copy</MenuItem>
+          {network?.explorer_url && (
+            <MenuItem
+              component="a"
+              target="_blank"
+              href={
+                network.explorer_url +
+                (label || contextMenu?.target.textContent)
+              }
+              rel="noreferrer"
+              onClick={onCloseMenu}
+            >
+              Open in explorer
+            </MenuItem>
+          )}
+        </Menu>
+      )}
+    </>
+  );
+}

--- a/gui/src/components/Contracts.tsx
+++ b/gui/src/components/Contracts.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { useInvoke } from "../hooks/tauri";
 import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
 import { Address } from "../types";
-import { CopyToClipboard } from "./CopyToClipboard";
+import { ContextMenu } from "./ContextMenu";
 import Panel from "./Panel";
 
 export function Contracts() {
@@ -26,9 +26,9 @@ export function Contracts() {
 function Contract({ address }: { address: Address }) {
   return (
     <ListItem>
-      <CopyToClipboard>
+      <ContextMenu>
         <Typography>{address}</Typography>
-      </CopyToClipboard>
+      </ContextMenu>
     </ListItem>
   );
 }

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -10,6 +10,7 @@ import { Connections } from "./Connections";
 import { Contracts } from "./Contracts";
 import { Details } from "./Details";
 import { LivenetPlaceholder } from "./LivenetPlaceholder";
+import { NestedRoutes } from "./NestedRoutes";
 import { Txs } from "./Txs";
 
 const tabs = [
@@ -21,7 +22,7 @@ const tabs = [
 ];
 
 export function HomePage() {
-  const [_match, params] = useRoute(":path");
+  const [_match, params] = useRoute("/:path");
   const [_location, setLocation] = useLocation();
 
   useMenuAction((payload) => setLocation(payload));
@@ -61,18 +62,20 @@ export function HomePage() {
         </Tabs>
 
         <div role="tabpanel">
-          <Switch>
-            {tabs.map((tab) => (
-              <Route key={tab.path || "/"} path={tab.path}>
-                <LivenetPlaceholder devOnly={tab.devOnly}>
-                  <tab.component />
-                </LivenetPlaceholder>
+          <NestedRoutes base="/">
+            <Switch>
+              {tabs.map((tab) => (
+                <Route key={tab.path || "/"} path={tab.path}>
+                  <LivenetPlaceholder devOnly={tab.devOnly}>
+                    <tab.component />
+                  </LivenetPlaceholder>
+                </Route>
+              ))}
+              <Route>
+                <Details />
               </Route>
-            ))}
-            <Route>
-              <Details />
-            </Route>
-          </Switch>
+            </Switch>
+          </NestedRoutes>
         </div>
       </Paper>
     </Container>

--- a/gui/src/components/Txs.tsx
+++ b/gui/src/components/Txs.tsx
@@ -16,7 +16,7 @@ import truncateEthAddress from "truncate-eth-address";
 import { useAccount, useProvider } from "../hooks";
 import { useInvoke } from "../hooks/tauri";
 import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
-import { CopyToClipboard } from "./CopyToClipboard";
+import { ContextMenu } from "./ContextMenu";
 import Panel from "./Panel";
 
 export function Txs() {
@@ -69,28 +69,28 @@ function Receipt({ hash }: { hash: string }) {
         ></Box>
       </ListItemAvatar>
       <Stack mb={1}>
-        <CopyToClipboard>
+        <ContextMenu>
           <Typography>{hash}</Typography>
-        </CopyToClipboard>
+        </ContextMenu>
         <Box sx={{ fontSize: 12 }}>
           <Box>
             From:{" "}
-            <CopyToClipboard label={receipt.from}>
+            <ContextMenu label={receipt.from}>
               {truncateEthAddress(receipt.from)}
-            </CopyToClipboard>
+            </ContextMenu>
           </Box>
           <Box>
             To:{" "}
             {receipt.to ? (
-              <CopyToClipboard label={receipt.to}>
+              <ContextMenu label={receipt.to}>
                 {truncateEthAddress(receipt.to)}
-              </CopyToClipboard>
+              </ContextMenu>
             ) : (
               "Contract Deploy"
             )}
           </Box>
           <Box>
-            Amount: <CopyToClipboard>{formatEther(tx.value)}</CopyToClipboard> Ξ
+            Amount: <ContextMenu>{formatEther(tx.value)}</ContextMenu> Ξ
           </Box>
         </Box>
       </Stack>

--- a/gui/src/hooks/useNetwork.ts
+++ b/gui/src/hooks/useNetwork.ts
@@ -1,0 +1,10 @@
+import { Network } from "../types";
+import { useInvoke } from "./tauri";
+
+export function useNetwork() {
+  const { data: network, mutate: refresh } = useInvoke<Network>(
+    "get_current_network"
+  );
+
+  return { network, refresh };
+}

--- a/gui/src/hooks/useNetwork.ts
+++ b/gui/src/hooks/useNetwork.ts
@@ -2,9 +2,7 @@ import { Network } from "../types";
 import { useInvoke } from "./tauri";
 
 export function useNetwork() {
-  const { data: network, mutate: refresh } = useInvoke<Network>(
-    "get_current_network"
-  );
+  const { data: network, mutate } = useInvoke<Network>("get_current_network");
 
-  return { network, refresh };
+  return { network, mutate };
 }


### PR DESCRIPTION
The context menu is rudimentary for now, allowing copying and opening in the set explorer. It's a complex component because it does some magic, but it's a component we can easily reuse and extend to most scenarios.

Ideally, we would use native dialogs, but it's not supported by Tauri yet, so we'll have to stick with the material component for now!