### PR TITLE
Extracts Peers out of Context

### DIFF
--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -6,11 +6,11 @@ import { Link, Route, Switch, useLocation, useRoute } from "wouter";
 import { useKeyPress } from "../hooks/useKeyPress";
 import { useMenuAction } from "../hooks/useMenuAction";
 import { Balances } from "./Balances";
-import { Connections } from "./Connections";
 import { Contracts } from "./Contracts";
 import { Details } from "./Details";
 import { LivenetPlaceholder } from "./LivenetPlaceholder";
 import { NestedRoutes } from "./NestedRoutes";
+import { Peers } from "./Peers";
 import { Txs } from "./Txs";
 
 const tabs = [
@@ -18,7 +18,7 @@ const tabs = [
   { path: "transactions", name: "Transactions", component: Txs, devOnly: true },
   { path: "balances", name: "Balances", component: Balances, devOnly: true },
   { path: "contracts", name: "Contracts", component: Contracts, devOnly: true },
-  { path: "connections", name: "Connections", component: Connections },
+  { path: "connections", name: "Connections", component: Peers },
 ];
 
 export function HomePage() {

--- a/gui/src/components/Peers.tsx
+++ b/gui/src/components/Peers.tsx
@@ -1,12 +1,11 @@
 import { Box, Stack, Typography } from "@mui/material";
 import { groupBy, map } from "lodash";
-import React from "react";
 
 import { useInvoke } from "../hooks/tauri";
-import { useRefreshConnections } from "../hooks/useRefreshConnections";
+import { useRefreshPeers } from "../hooks/useRefreshPeers";
 import Panel from "./Panel";
 
-interface Connection {
+interface Peer {
   origin: string;
   tab_id?: number;
   title?: string;
@@ -15,18 +14,17 @@ interface Connection {
   favicon: string;
 }
 
-export function Connections() {
-  const { data: connections, mutate } =
-    useInvoke<Connection[]>("get_connections");
+export function Peers() {
+  const { data: peers, mutate } = useInvoke<Peer[]>("peers_get_all");
 
-  useRefreshConnections(mutate);
+  useRefreshPeers(mutate);
 
-  const connectionsByTabId = groupBy(connections, "tab_id");
+  const peersByTabId = groupBy(peers, "tab_id");
 
   return (
     <Panel>
       <Stack spacing={2}>
-        {map(connectionsByTabId, (conns, tabId) => (
+        {map(peersByTabId, (conns, tabId) => (
           <Connection key={tabId} tabId={tabId} conns={conns} />
         ))}
       </Stack>
@@ -34,7 +32,7 @@ export function Connections() {
   );
 }
 
-function Connection({ tabId, conns }: { tabId?: string; conns: Connection[] }) {
+function Connection({ tabId, conns }: { tabId?: string; conns: Peer[] }) {
   return (
     <Stack direction="row" spacing={2}>
       <Box
@@ -45,7 +43,7 @@ function Connection({ tabId, conns }: { tabId?: string; conns: Connection[] }) {
       <Stack>
         <Typography variant="overline"> {conns[0].title}</Typography>
         {tabId && <Typography variant="body2">Tab ID {tabId}</Typography>}
-        <Typography variant="body2">{conns.length} connections</Typography>
+        <Typography variant="body2">{conns.length} peers</Typography>
       </Stack>
     </Stack>
   );

--- a/gui/src/hooks/useRefreshPeers.ts
+++ b/gui/src/hooks/useRefreshPeers.ts
@@ -1,9 +1,9 @@
 import { listen } from "@tauri-apps/api/event";
 import { useEffect } from "react";
 
-export function useRefreshConnections(callback: () => unknown) {
+export function useRefreshPeers(callback: () => unknown) {
   useEffect(() => {
-    const unlisten = listen("connections-updated", () => {
+    const unlisten = listen("peers-updated", () => {
       callback();
     });
 

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -11,7 +11,7 @@ use tauri::{Menu, Submenu, WindowMenuEvent};
 use tauri_plugin_window_state::{AppHandleExt, Builder as windowStatePlugin, StateFlags};
 use tokio::sync::mpsc;
 
-use crate::{commands, context::Context, dialogs};
+use crate::{commands, context::Context, dialogs, peers};
 
 pub struct IronApp {
     pub sender: mpsc::UnboundedSender<Event>,
@@ -31,7 +31,7 @@ pub enum Event {
 pub enum Notify {
     NetworkChanged,
     TxsUpdated,
-    ConnectionsUpdated,
+    PeersUpdated,
 }
 
 impl Notify {
@@ -39,7 +39,7 @@ impl Notify {
         match self {
             Self::NetworkChanged => "network-changed",
             Self::TxsUpdated => "txs-updated",
-            Self::ConnectionsUpdated => "connections-updated",
+            Self::PeersUpdated => "peers-updated",
         }
     }
 }
@@ -76,6 +76,7 @@ impl IronApp {
                 commands::get_connections,
                 commands::derive_addresses,
                 commands::derive_addresses_with_mnemonic,
+                peers::commands::peers_get_all,
                 dialogs::dialog_get_payload,
                 dialogs::dialog_finish,
             ])

--- a/tauri/src/context/wallet.rs
+++ b/tauri/src/context/wallet.rs
@@ -6,6 +6,7 @@ use serde::de::{self, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
+use crate::types::ChecksummedAddress;
 
 #[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -81,6 +82,10 @@ impl Wallet {
 
     pub fn checksummed_address(&self) -> String {
         to_checksum(&self.signer.address(), None)
+    }
+
+    pub fn get_current_address(&self) -> ChecksummedAddress {
+        self.signer.address().into()
     }
 
     pub fn update_chain_id(&mut self, chain_id: u32) {

--- a/tauri/src/main.rs
+++ b/tauri/src/main.rs
@@ -8,12 +8,16 @@ mod context;
 mod db;
 mod dialogs;
 mod error;
+mod peers;
 mod rpc;
 mod store;
+mod types;
 mod ws;
 
 use context::Context;
 use error::Result;
+use peers::Peers;
+use types::GlobalState;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -22,6 +26,7 @@ async fn main() -> Result<()> {
     fix_path_env::fix()?;
 
     let mut app = app::IronApp::build();
+    Peers::init(app.sender.clone()).await;
 
     // now we're able to build our context
     // this relies on $APPDIR retrieved from Tauri

--- a/tauri/src/peers/commands.rs
+++ b/tauri/src/peers/commands.rs
@@ -1,0 +1,7 @@
+use super::Peers;
+use crate::{types::GlobalState, ws::Peer};
+
+#[tauri::command]
+pub async fn peers_get_all() -> Result<Vec<Peer>, String> {
+    Ok(Peers::read().await.get_all())
+}

--- a/tauri/src/peers/global.rs
+++ b/tauri/src/peers/global.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use tokio::sync::{mpsc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use super::Peers;
+use crate::{app, types::GlobalState};
+
+static PEERS: Lazy<RwLock<Peers>> = Lazy::new(Default::default);
+
+#[async_trait]
+impl GlobalState for Peers {
+    /// The only needed state to initialize `Peers` is a sender to the tauri event loop
+    type Initializer = mpsc::UnboundedSender<app::Event>;
+
+    async fn init(sender: Self::Initializer) {
+        let mut peers = PEERS.write().await;
+        peers.window_snd = Some(sender);
+    }
+
+    async fn read<'a>() -> RwLockReadGuard<'a, Self> {
+        PEERS.read().await
+    }
+
+    async fn write<'a>() -> RwLockWriteGuard<'a, Self> {
+        PEERS.write().await
+    }
+}

--- a/tauri/src/peers/mod.rs
+++ b/tauri/src/peers/mod.rs
@@ -1,0 +1,73 @@
+pub mod commands;
+mod global;
+
+use std::{collections::HashMap, net::SocketAddr};
+
+use log::warn;
+use serde::Serialize;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use crate::{app, types::ChecksummedAddress, ws::Peer};
+
+/// Tracks a list of peers, usually browser tabs, that connect to the app
+#[derive(Debug, Default)]
+pub struct Peers {
+    map: HashMap<SocketAddr, Peer>,
+    window_snd: Option<mpsc::UnboundedSender<app::Event>>,
+}
+
+impl Peers {
+    /// Adds a new peer
+    pub fn add_peer(&mut self, peer: Peer) {
+        self.map.insert(peer.socket, peer);
+        self.window_snd
+            .as_ref()
+            .unwrap()
+            .send(app::Notify::PeersUpdated.into())
+            .unwrap();
+    }
+
+    /// Removes an existing peer
+    pub fn remove_peer(&mut self, peer: SocketAddr) {
+        self.map.remove(&peer);
+        self.window_snd
+            .as_ref()
+            .unwrap()
+            .send(app::Notify::PeersUpdated.into())
+            .unwrap();
+    }
+
+    /// Broadcasts an `accountsChanged` event to all peers
+    pub fn broadcast_accounts_changed(&self, new_accounts: Vec<ChecksummedAddress>) {
+        self.broadcast(json!({
+            "method": "accountsChanged",
+            "params": new_accounts
+        }));
+    }
+
+    /// Broadcasts a `chainChanged` event to all peers
+    pub fn broadcast_chain_changed(&self, chain_id: u32, name: String) {
+        self.broadcast(json!({
+            "method": "chainChanged",
+            "params": {
+                "chainId": format!("0x{:x}", chain_id),
+                "networkVersion": name
+            }
+        }));
+    }
+
+    fn broadcast<T: Serialize + std::fmt::Debug>(&self, msg: T) {
+        self.map.iter().for_each(|(_, peer)| {
+            peer.sender
+                .send(serde_json::to_value(&msg).unwrap())
+                .unwrap_or_else(|e| {
+                    warn!("Failed to send message to peer: {}", e);
+                });
+        });
+    }
+
+    fn get_all(&self) -> Vec<Peer> {
+        self.map.values().cloned().collect()
+    }
+}

--- a/tauri/src/types/checksummed_address.rs
+++ b/tauri/src/types/checksummed_address.rs
@@ -1,0 +1,20 @@
+use ethers::{types::Address, utils::to_checksum};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct ChecksummedAddress(Address);
+
+impl Serialize for ChecksummedAddress {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&to_checksum(&self.0, None))
+    }
+}
+
+impl From<Address> for ChecksummedAddress {
+    fn from(value: Address) -> Self {
+        Self(value)
+    }
+}

--- a/tauri/src/types/global_state.rs
+++ b/tauri/src/types/global_state.rs
@@ -1,0 +1,18 @@
+use tokio::sync::{RwLockReadGuard, RwLockWriteGuard};
+
+/// Defines a global state, distinguishing reads from writes
+/// Meant to be declared as `OnceCell<RwLock<State>>` or `Lazy<RwLock<State>>`
+#[async_trait::async_trait]
+pub trait GlobalState {
+    type Initializer;
+
+    /// initializees the global state
+    /// future read/write calls assume this has previously been called
+    async fn init(initializer: Self::Initializer);
+
+    /// acquires a read-only handle to the global state
+    async fn read<'a>() -> RwLockReadGuard<'a, Self>;
+
+    /// acquires an exclusive write handle to the global state
+    async fn write<'a>() -> RwLockWriteGuard<'a, Self>;
+}

--- a/tauri/src/types/mod.rs
+++ b/tauri/src/types/mod.rs
@@ -1,0 +1,5 @@
+mod global_state;
+mod checksummed_address;
+
+pub use checksummed_address::ChecksummedAddress;
+pub use global_state::GlobalState;


### PR DESCRIPTION
This change was taken out of #163 , to simplify that PR
this changes nothing in terms of features, and settings files, because this particular field is not persisted. It also has the least interaction with other parts of the Context, so its easy to extract