### PR TITLE
Refactoring SendTransaction

### DIFF
--- a/tauri/src/rpc/error.rs
+++ b/tauri/src/rpc/error.rs
@@ -3,9 +3,13 @@ use ethers::{
     signers,
 };
 use ethers_core::k256::ecdsa::SigningKey;
+use jsonrpc_core::ErrorCode;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("Transaction rejected")]
+    TxDialogRejected,
+
     #[error(transparent)]
     SignerMiddlewareError(
         #[from] SignerMiddlewareError<Provider<Http>, signers::Wallet<SigningKey>>,
@@ -13,3 +17,13 @@ pub enum Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<Error> for jsonrpc_core::Error {
+    fn from(value: Error) -> Self {
+        Self {
+            code: ErrorCode::ServerError(0),
+            data: None,
+            message: value.to_string(),
+        }
+    }
+}

--- a/tauri/src/rpc/send_transaction.rs
+++ b/tauri/src/rpc/send_transaction.rs
@@ -7,48 +7,54 @@ use ethers::{
 };
 use ethers_core::k256::ecdsa::SigningKey;
 
-use super::Result;
+use super::{Error, Result};
 
+#[derive(Default)]
 pub struct SendTransaction {
+    pub dialog: bool,
     pub request: TypedTransaction,
     pub signer: Option<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
 }
 
 impl SendTransaction {
-    pub fn build(params: serde_json::Value) -> Self {
+    pub fn set_params(&mut self, params: serde_json::Value) -> &mut Self {
         // TODO: why is this an array?
         let params = &params.as_array().unwrap()[0];
 
-        let mut request = TypedTransaction::default();
+        if let Some(from) = params["from"].as_str() {
+            self.request.set_from(Address::from_str(from).unwrap());
+        }
 
-        request
-            .set_from(Address::from_str(params[""].as_str().unwrap()).unwrap())
-            .set_to(Address::from_str(params["to"].as_str().unwrap()).unwrap());
+        if let Some(to) = params["to"].as_str() {
+            self.request.set_to(Address::from_str(to).unwrap());
+        }
 
         if let Some(value) = params["value"].as_str() {
             let v = StringifiedNumeric::String(value.to_string());
-            request.set_value(U256::try_from(v).unwrap());
+            self.request.set_value(U256::try_from(v).unwrap());
         }
 
         if let Some(data) = params["data"].as_str() {
-            request.set_data(Bytes::from_str(data).unwrap());
+            self.request.set_data(Bytes::from_str(data).unwrap());
         }
 
-        Self {
-            request,
-            signer: Default::default(),
-        }
+        self
     }
 
-    pub fn set_chain_id(&mut self, chain_id: u32) {
+    pub fn set_chain_id(&mut self, chain_id: u32) -> &mut Self {
         self.request.set_chain_id(chain_id);
+        self
     }
 
-    pub fn set_signer(&mut self, signer: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>) {
+    pub fn set_signer(
+        &mut self,
+        signer: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
+    ) -> &mut Self {
         self.signer = Some(signer);
+        self
     }
 
-    pub async fn estimate_gas(&mut self) {
+    pub async fn estimate_gas(&mut self) -> &mut Self {
         // TODO: we're defaulting to 1_000_000 gas cost if estimation fails
         // estimation failing means the tx will faill anyway, so this is fine'ish
         // but can probably be improved a lot in the future
@@ -61,6 +67,25 @@ impl SendTransaction {
             .unwrap_or(1_000_000.into());
 
         self.request.set_gas(gas_limit * 120 / 100);
+        self
+    }
+
+    pub async fn spawn_dialog(&mut self) -> Result<()> {
+        let params = serde_json::to_value(&self.request).unwrap();
+
+        let rcv = crate::dialogs::open("tx-review", params).unwrap();
+
+        match rcv.await {
+            // 1st case is if the channel closes. 2nd case is if "Reject" is hit
+            Err(_) | Ok(Err(_)) => 
+                // TODO: what's the appropriate error to return here?
+                // or should we return Ok(_)? Err(_) seems to close the ws connection
+                Err(Error::TxDialogRejected),
+            
+            Ok(Ok(_response)) => 
+                Ok(())
+                // TODO: in the future, send json values here to override params
+        }
     }
 
     pub async fn send(&mut self) -> Result<PendingTransaction<'_, Http>> {


### PR DESCRIPTION
cleans up send_transaction rpc call. moves all logic (including dialog), into `SendTransaction` builder object

this is needed to be able to re-use the entire transaction flow from within tauri commands