### PR TITLE
Fixes wei value tracking; Adds "copy to clipboard" to wei values

### DIFF
--- a/gui/src/components/Txs.tsx
+++ b/gui/src/components/Txs.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
+import { grey } from "@mui/material/colors";
 import { createElement, useEffect } from "react";
 import useSWR from "swr";
 import { type TransactionReceipt, formatEther } from "viem";
@@ -56,6 +57,8 @@ function Receipt({ account, tx }: ReceiptProps) {
     ([, hash]) => provider?.getTransactionReceipt({ hash })
   );
 
+  const value = BigInt(tx.value);
+
   useEffect(() => {
     mutate();
   }, [provider, mutate]);
@@ -83,7 +86,11 @@ function Receipt({ account, tx }: ReceiptProps) {
         </Stack>
       </Box>
       <Box>
-        <ContextMenu>{formatEther(BigInt(tx.value))} Ξ</ContextMenu>
+        {value > 0n && (
+          <ContextMenu copy={value.toString()}>
+            {formatEther(value)} Ξ
+          </ContextMenu>
+        )}
       </Box>
     </ListItem>
   );

--- a/tauri/src/db/queries.rs
+++ b/tauri/src/db/queries.rs
@@ -7,8 +7,8 @@ type Query<'a> = sqlx::query::Query<'a, Sqlite, sqlx::sqlite::SqliteArguments<'a
 
 pub(super) fn insert_transaction(tx: &events::Tx, chain_id: u32) -> Query {
     sqlx::query(
-        r#" INSERT INTO transactions (hash, chain_id, from_address, to_address, block_number, position)
-        VALUES (?,?,?,?,?,?)
+        r#" INSERT INTO transactions (hash, chain_id, from_address, to_address, block_number, position, value)
+        VALUES (?,?,?,?,?,?,?)
         ON CONFLICT(hash) DO NOTHING "#,
     )
     .bind(format!("0x{:x}", tx.hash))
@@ -17,6 +17,7 @@ pub(super) fn insert_transaction(tx: &events::Tx, chain_id: u32) -> Query {
     .bind(tx.to.map(|a| format!("0x{:x}", a)))
     .bind(tx.block_number as i64)
     .bind(tx.position.unwrap_or(0) as u32)
+    .bind(tx.value.to_string())
 }
 
 pub(super) fn insert_contract(

--- a/tauri/src/types/events.rs
+++ b/tauri/src/types/events.rs
@@ -211,7 +211,7 @@ impl TryFrom<&SqliteRow> for Tx {
             hash: H256::from_str(row.get("hash")).unwrap(),
             from: Address::from_str(row.get("from_address")).unwrap(),
             to: Address::from_str(row.get("to_address")).ok(),
-            value: U256::from_str(row.get("value")).unwrap(),
+            value: U256::from_str_radix(row.get("value"), 10).unwrap(),
             data: Bytes::from_str(row.get("data")).unwrap(),
             block_number: row.get::<i64, _>("block_number") as u64,
             position: Some(row.get::<i32, _>("position") as usize),


### PR DESCRIPTION
We can now "copy to clipboard" wei values, which will copy the raw wei instead of the presented unit.

In the process, I noticed we weren't correctly tracking the wei value of transactions. So now we are