### PR TITLE
hide empty tokens in details ui

### DIFF
--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -6,7 +6,7 @@ import { useBalance, useContractRead } from "wagmi";
 import { useAccount } from "../hooks";
 import { useInvoke } from "../hooks/tauri";
 import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
-import { Address } from "../types";
+import { Address, GeneralSettings } from "../types";
 import { CopyToClipboard } from "./CopyToClipboard";
 import Panel from "./Panel";
 
@@ -16,6 +16,12 @@ export function Balances() {
     "db_get_erc20_balances",
     { address }
   );
+  const { data: settings } = useInvoke<GeneralSettings>("settings_get");
+
+  const reorderedBalances = (balances || [])
+    .map<[`0x${string}`, bigint]>(([c, b]) => [c, BigInt(b)]) // is it possible to get the proper type from backend directly?
+    .filter(([, balance]) => (settings?.hideEmptyTokens ? !!balance : true))
+    .sort(([, a], [, b]) => (b > a ? 1 : b < a ? -1 : 0));
 
   useRefreshTransactions(mutate);
 
@@ -23,13 +29,11 @@ export function Balances() {
     <Panel>
       <Stack>
         {address && <BalanceETH address={address} />}
-        {(balances || []).map(([contract, balance]) => (
+        {reorderedBalances.map(([contract, balance]) => (
           <BalanceERC20
             key={contract}
-            {...{
-              contract,
-              balance: BigInt(balance),
-            }}
+            contract={contract}
+            balance={BigInt(balance)}
           />
         ))}
       </Stack>

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -19,9 +19,8 @@ export function Balances() {
   const { data: settings } = useInvoke<GeneralSettings>("settings_get");
 
   const reorderedBalances = (balances || [])
-    .map<[`0x${string}`, bigint]>(([c, b]) => [c, BigInt(b)]) // is it possible to get the proper type from backend directly?
-    .filter(([, balance]) => (settings?.hideEmptyTokens ? !!balance : true))
-    .sort(([, a], [, b]) => (b > a ? 1 : b < a ? -1 : 0));
+    .map<[Address, bigint]>(([c, b]) => [c, BigInt(b)])
+    .filter(([, balance]) => (settings?.hideEmptyTokens ? !!balance : true));
 
   useRefreshTransactions(mutate);
 

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -18,7 +18,7 @@ export function Balances() {
   );
   const { data: settings } = useInvoke<GeneralSettings>("settings_get");
 
-  const reorderedBalances = (balances || [])
+  const filteredBalances = (balances || [])
     .map<[Address, bigint]>(([c, b]) => [c, BigInt(b)])
     .filter(([, balance]) => (settings?.hideEmptyTokens ? !!balance : true));
 
@@ -28,12 +28,8 @@ export function Balances() {
     <Panel>
       <Stack>
         {address && <BalanceETH address={address} />}
-        {reorderedBalances.map(([contract, balance]) => (
-          <BalanceERC20
-            key={contract}
-            contract={contract}
-            balance={BigInt(balance)}
-          />
+        {filteredBalances.map(([contract, balance]) => (
+          <BalanceERC20 key={contract} contract={contract} balance={balance} />
         ))}
       </Stack>
     </Panel>

--- a/gui/src/components/SettingsGeneral.tsx
+++ b/gui/src/components/SettingsGeneral.tsx
@@ -105,6 +105,26 @@ export function SettingsGeneral() {
           fullWidth
           {...register("abiWatchPath")}
         />
+        <FormControl error={!!errors.hideEmptyTokens}>
+          <FormGroup>
+            <FormControlLabel
+              label="Hide Tokens Without Balance"
+              control={
+                <Controller
+                  name="hideEmptyTokens"
+                  control={control}
+                  render={({ field }) => (
+                    <Checkbox
+                      {...field}
+                      checked={field.value}
+                      onChange={(e) => field.onChange(e.target.checked)}
+                    />
+                  )}
+                />
+              }
+            />
+          </FormGroup>
+        </FormControl>
         <Button
           variant="contained"
           type="submit"

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -4,6 +4,7 @@ export const generalSettingsSchema = z.object({
   darkMode: z.enum(["auto", "dark", "light"]),
   abiWatch: z.boolean().default(false),
   abiWatchPath: z.string().optional(),
+  hideEmptyTokens: z.boolean(),
 });
 
 // const formSchema = schema.shape.network;

--- a/tauri/src/settings/mod.rs
+++ b/tauri/src/settings/mod.rs
@@ -81,6 +81,7 @@ pub struct SerializedSettings {
     pub abi_watch: bool,
     pub abi_watch_path: Option<String>,
     pub alchemy_api_key: Option<String>,
+    pub hide_empty_tokens: bool,
 
     #[serde(default = "default_aliases")]
     aliases: HashMap<ChecksummedAddress, String>,
@@ -93,6 +94,7 @@ impl Default for SerializedSettings {
             abi_watch: false,
             abi_watch_path: None,
             alchemy_api_key: None,
+            hide_empty_tokens: true,
             aliases: HashMap::new(),
         }
     }

--- a/tauri/src/settings/mod.rs
+++ b/tauri/src/settings/mod.rs
@@ -81,6 +81,7 @@ pub struct SerializedSettings {
     pub abi_watch: bool,
     pub abi_watch_path: Option<String>,
     pub alchemy_api_key: Option<String>,
+    #[serde(default = "default_true")]
     pub hide_empty_tokens: bool,
 
     #[serde(default = "default_aliases")]
@@ -98,6 +99,10 @@ impl Default for SerializedSettings {
             aliases: HashMap::new(),
         }
     }
+}
+
+const fn default_true() -> bool {
+    true
 }
 
 fn default_aliases() -> HashMap<ChecksummedAddress, String> {


### PR DESCRIPTION
Add a checkbox in settings to allow users to decide if they want to see empty tokens in the details ui page or not.
![image](https://github.com/iron-wallet/iron/assets/97689347/e7500e3e-153a-4236-8a02-a7911c2c9eb4)
![image](https://github.com/iron-wallet/iron/assets/97689347/47eb7efd-d124-4ad0-9012-613b6dde0a4d)
