### PR TITLE
add text field for alchemy api key in ui settings

### DIFF
--- a/gui/src/components/SettingsGeneral.tsx
+++ b/gui/src/components/SettingsGeneral.tsx
@@ -105,6 +105,13 @@ export function SettingsGeneral() {
           fullWidth
           {...register("abiWatchPath")}
         />
+        <TextField
+          label="Alchemy API Key"
+          {...register("alchemyApiKey")}
+          fullWidth
+          error={!!errors.alchemyApiKey}
+          helperText={errors.alchemyApiKey?.message?.toString()}
+        />
         <Button
           variant="contained"
           type="submit"

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 
 export const generalSettingsSchema = z.object({
   darkMode: z.enum(["auto", "dark", "light"]),
-  abiWatch: z.boolean().default(false),
-  abiWatchPath: z.string().optional(),
+  abiWatch: z.boolean(),
+  abiWatchPath: z.string().optional().nullable(),
+  alchemyApiKey: z.string().optional().nullable(),
 });
 
 // const formSchema = schema.shape.network;


### PR DESCRIPTION
Add a text field to the UI settings to add an Alchemy api key to be used in the future to get the current account token list and balances. This is to be only used in live networks.

![image](https://github.com/iron-wallet/iron/assets/97689347/ca032fb3-f0eb-47c1-a992-e161c606a67a)
