### PR TITLE
Live networks balances auto request

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -6,6 +6,7 @@ import { CommandBar, CommandBarProvider } from "./components/CommandBar";
 import { HomePage } from "./components/HomePage";
 import { JsonKeystoreUnlockDialog } from "./components/JsonKeystoreUnlockDialog";
 import { Navbar } from "./components/Navbar";
+import { ProviderCurrentNetwork } from "./components/ProviderCurrentNetwork";
 import { ProviderNetworks } from "./components/ProviderNetworks";
 import { ProviderTheme } from "./components/ProviderTheme";
 import { ProviderTokensBalances } from "./components/ProviderTokensBalances";
@@ -26,30 +27,32 @@ export default function App() {
             <WagmiWrapper>
               <ProviderWallets>
                 <ProviderNetworks>
-                  <ProviderTokensBalances>
-                    <Router>
-                      <Switch>
-                        <Route path="/dialog/tx-review/:id">
-                          {({ id }: { id: string }) => (
-                            <TxReviewDialog id={parseInt(id)} />
-                          )}
-                        </Route>
+                  <ProviderCurrentNetwork>
+                    <ProviderTokensBalances>
+                      <Router>
+                        <Switch>
+                          <Route path="/dialog/tx-review/:id">
+                            {({ id }: { id: string }) => (
+                              <TxReviewDialog id={parseInt(id)} />
+                            )}
+                          </Route>
 
-                        <Route path="/dialog/jsonkeystore-unlock/:id">
-                          {({ id }: { id: string }) => (
-                            <JsonKeystoreUnlockDialog id={parseInt(id)} />
-                          )}
-                        </Route>
+                          <Route path="/dialog/jsonkeystore-unlock/:id">
+                            {({ id }: { id: string }) => (
+                              <JsonKeystoreUnlockDialog id={parseInt(id)} />
+                            )}
+                          </Route>
 
-                        <Route>
-                          <CommandBar>
-                            <Navbar />
-                            <HomePage />
-                          </CommandBar>
-                        </Route>
-                      </Switch>
-                    </Router>
-                  </ProviderTokensBalances>
+                          <Route>
+                            <CommandBar>
+                              <Navbar />
+                              <HomePage />
+                            </CommandBar>
+                          </Route>
+                        </Switch>
+                      </Router>
+                    </ProviderTokensBalances>
+                  </ProviderCurrentNetwork>
                 </ProviderNetworks>
               </ProviderWallets>
             </WagmiWrapper>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -26,8 +26,8 @@ export default function App() {
           <QueryClientProvider client={queryClient}>
             <ProviderWallets>
               <ProviderNetworks>
-                <ProviderCurrentNetwork>
-                  <WagmiWrapper>
+                <WagmiWrapper>
+                  <ProviderCurrentNetwork>
                     <ProviderTokensBalances>
                       <Router>
                         <Switch>
@@ -52,8 +52,8 @@ export default function App() {
                         </Switch>
                       </Router>
                     </ProviderTokensBalances>
-                  </WagmiWrapper>
-                </ProviderCurrentNetwork>
+                  </ProviderCurrentNetwork>
+                </WagmiWrapper>
               </ProviderNetworks>
             </ProviderWallets>
           </QueryClientProvider>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -24,10 +24,10 @@ export default function App() {
       <ProviderTheme>
         <CssBaseline>
           <QueryClientProvider client={queryClient}>
-            <WagmiWrapper>
-              <ProviderWallets>
-                <ProviderNetworks>
-                  <ProviderCurrentNetwork>
+            <ProviderWallets>
+              <ProviderNetworks>
+                <ProviderCurrentNetwork>
+                  <WagmiWrapper>
                     <ProviderTokensBalances>
                       <Router>
                         <Switch>
@@ -52,10 +52,10 @@ export default function App() {
                         </Switch>
                       </Router>
                     </ProviderTokensBalances>
-                  </ProviderCurrentNetwork>
-                </ProviderNetworks>
-              </ProviderWallets>
-            </WagmiWrapper>
+                  </WagmiWrapper>
+                </ProviderCurrentNetwork>
+              </ProviderNetworks>
+            </ProviderWallets>
           </QueryClientProvider>
         </CssBaseline>
       </ProviderTheme>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -8,6 +8,7 @@ import { JsonKeystoreUnlockDialog } from "./components/JsonKeystoreUnlockDialog"
 import { Navbar } from "./components/Navbar";
 import { ProviderNetworks } from "./components/ProviderNetworks";
 import { ProviderTheme } from "./components/ProviderTheme";
+import { ProviderTokensBalances } from "./components/ProviderTokensBalances";
 import { ProviderWallets } from "./components/ProviderWallets";
 import { TxReviewDialog } from "./components/TxReviewDialog";
 import { WagmiWrapper } from "./components/WagmiWrapper";
@@ -25,28 +26,30 @@ export default function App() {
             <WagmiWrapper>
               <ProviderWallets>
                 <ProviderNetworks>
-                  <Router>
-                    <Switch>
-                      <Route path="/dialog/tx-review/:id">
-                        {({ id }: { id: string }) => (
-                          <TxReviewDialog id={parseInt(id)} />
-                        )}
-                      </Route>
+                  <ProviderTokensBalances>
+                    <Router>
+                      <Switch>
+                        <Route path="/dialog/tx-review/:id">
+                          {({ id }: { id: string }) => (
+                            <TxReviewDialog id={parseInt(id)} />
+                          )}
+                        </Route>
 
-                      <Route path="/dialog/jsonkeystore-unlock/:id">
-                        {({ id }: { id: string }) => (
-                          <JsonKeystoreUnlockDialog id={parseInt(id)} />
-                        )}
-                      </Route>
+                        <Route path="/dialog/jsonkeystore-unlock/:id">
+                          {({ id }: { id: string }) => (
+                            <JsonKeystoreUnlockDialog id={parseInt(id)} />
+                          )}
+                        </Route>
 
-                      <Route>
-                        <CommandBar>
-                          <Navbar />
-                          <HomePage />
-                        </CommandBar>
-                      </Route>
-                    </Switch>
-                  </Router>
+                        <Route>
+                          <CommandBar>
+                            <Navbar />
+                            <HomePage />
+                          </CommandBar>
+                        </Route>
+                      </Switch>
+                    </Router>
+                  </ProviderTokensBalances>
                 </ProviderNetworks>
               </ProviderWallets>
             </WagmiWrapper>

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -1,6 +1,5 @@
 import { Stack, Typography } from "@mui/material";
 import { erc20ABI } from "@wagmi/core";
-import { useEffect, useState } from "react";
 import { formatUnits } from "viem";
 import { useBalance, useContractRead } from "wagmi";
 
@@ -39,9 +38,7 @@ function BalancesERC20() {
   return (
     <>
       {balances.map(([contract, balance]) => (
-        <Delayed key={contract} waitBeforeShow={0}>
-          <BalanceERC20 contract={contract} balance={balance} />
-        </Delayed>
+        <BalanceERC20 key={contract} contract={contract} balance={balance} />
       ))}
     </>
   );
@@ -73,23 +70,4 @@ function BalanceERC20({
       {name} <CopyToClipboard>{formatUnits(balance, decimals)}</CopyToClipboard>
     </Typography>
   );
-}
-
-function Delayed({
-  children,
-  waitBeforeShow = 500,
-}: {
-  children: React.ReactNode;
-  waitBeforeShow?: number;
-}) {
-  const [isShown, setIsShown] = useState(false);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsShown(true);
-    }, waitBeforeShow);
-    return () => clearTimeout(timer);
-  }, [waitBeforeShow]);
-
-  return isShown ? <>{children}</> : null;
 }

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -4,26 +4,20 @@ import { formatUnits } from "viem";
 import { useBalance, useContractRead } from "wagmi";
 
 import { useAccount } from "../hooks";
-import { useInvoke } from "../hooks/tauri";
-import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
+import { useTokensBalances } from "../hooks/useTokensBalances";
 import { Address } from "../types";
 import { CopyToClipboard } from "./CopyToClipboard";
 import Panel from "./Panel";
 
 export function Balances() {
   const address = useAccount();
-  const { data: balances, mutate } = useInvoke<[Address, string][]>(
-    "db_get_erc20_balances",
-    { address }
-  );
-
-  useRefreshTransactions(mutate);
+  const { balances } = useTokensBalances();
 
   return (
     <Panel>
       <Stack>
         {address && <BalanceETH address={address} />}
-        {(balances || []).map(([contract, balance]) => (
+        {balances.map(([contract, balance]) => (
           <BalanceERC20
             key={contract}
             {...{

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -1,9 +1,9 @@
 import { Stack, Typography } from "@mui/material";
-import { erc20ABI } from "@wagmi/core";
 import { formatUnits } from "viem";
-import { useBalance, useContractRead } from "wagmi";
+import { erc20ABI, useBalance, useContractRead } from "wagmi";
 
 import { useAccount } from "../hooks";
+import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { useTokensBalances } from "../hooks/useTokensBalances";
 import { Address } from "../types";
 import { CopyToClipboard } from "./CopyToClipboard";
@@ -22,7 +22,12 @@ export function Balances() {
 
 function BalanceETH() {
   const address = useAccount();
-  const { data: balance } = useBalance({ address, enabled: !!address });
+  const { currentNetwork } = useCurrentNetwork();
+  const { data: balance } = useBalance({
+    address,
+    enabled: !!address,
+    chainId: currentNetwork?.chain_id,
+  });
 
   if (!balance) return null;
 
@@ -35,10 +40,16 @@ function BalanceETH() {
 
 function BalancesERC20() {
   const { balances } = useTokensBalances();
+  const { currentNetwork } = useCurrentNetwork();
   return (
     <>
       {balances.map(([contract, balance]) => (
-        <BalanceERC20 key={contract} contract={contract} balance={balance} />
+        <BalanceERC20
+          key={contract}
+          contract={contract}
+          balance={balance}
+          chainId={currentNetwork?.chain_id}
+        />
       ))}
     </>
   );
@@ -47,20 +58,24 @@ function BalancesERC20() {
 function BalanceERC20({
   contract,
   balance,
+  chainId,
 }: {
   contract: Address;
   balance: bigint;
+  chainId?: number;
 }) {
   const { data: name } = useContractRead({
     address: contract,
     abi: erc20ABI,
     functionName: "symbol",
+    chainId,
   });
 
   const { data: decimals } = useContractRead({
     address: contract,
     abi: erc20ABI,
     functionName: "decimals",
+    chainId,
   });
 
   if (!name || !decimals) return null;

--- a/gui/src/components/ContextMenu.tsx
+++ b/gui/src/components/ContextMenu.tsx
@@ -2,6 +2,7 @@ import { Button, Menu, MenuItem, SxProps, Tooltip } from "@mui/material";
 import { writeText } from "@tauri-apps/api/clipboard";
 import React, { MouseEvent, ReactNode, useState } from "react";
 
+import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { useNetworks } from "../hooks/useNetworks";
 
 interface Props {
@@ -29,7 +30,7 @@ const buttonSx = {
 };
 
 export function ContextMenu({ children, sx, copy, explorer, actions }: Props) {
-  const { currentNetwork } = useNetworks();
+  const { currentNetwork } = useCurrentNetwork();
   const [copied, setCopied] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
     target: HTMLElement;

--- a/gui/src/components/ContextMenu.tsx
+++ b/gui/src/components/ContextMenu.tsx
@@ -3,7 +3,6 @@ import { writeText } from "@tauri-apps/api/clipboard";
 import React, { MouseEvent, ReactNode, useState } from "react";
 
 import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
-import { useNetworks } from "../hooks/useNetworks";
 
 interface Props {
   children: ReactNode;

--- a/gui/src/components/ProviderCurrentNetwork.tsx
+++ b/gui/src/components/ProviderCurrentNetwork.tsx
@@ -1,0 +1,36 @@
+import { invoke } from "@tauri-apps/api/tauri";
+import { ReactNode, createContext } from "react";
+
+import { useInvoke } from "../hooks/tauri";
+import { useRefreshNetwork } from "../hooks/useRefreshNetwork";
+import { Network } from "../types";
+
+interface Value {
+  currentNetwork?: Network;
+  setCurrentNetwork: (newNetwork: string) => Promise<unknown>;
+}
+
+export const CurrentNetworkContext = createContext<Value>({} as Value);
+
+export function ProviderCurrentNetwork({ children }: { children: ReactNode }) {
+  const { data: currentNetwork, mutate: mutateNetwork } = useInvoke<Network>(
+    "networks_get_current"
+  );
+
+  const value = {
+    currentNetwork,
+    setCurrentNetwork: async (newNetwork: string) => {
+      if (currentNetwork?.name === newNetwork) return;
+
+      await invoke("networks_set_current", { network: newNetwork });
+    },
+  };
+
+  useRefreshNetwork(mutateNetwork);
+
+  return (
+    <CurrentNetworkContext.Provider value={value}>
+      {children}
+    </CurrentNetworkContext.Provider>
+  );
+}

--- a/gui/src/components/ProviderNetworks.tsx
+++ b/gui/src/components/ProviderNetworks.tsx
@@ -1,9 +1,7 @@
 import { invoke } from "@tauri-apps/api/tauri";
-import { useRegisterActions } from "kbar";
 import { ReactNode, createContext } from "react";
 
 import { useInvoke } from "../hooks/tauri";
-import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { useRefreshNetwork } from "../hooks/useRefreshNetwork";
 import { Network } from "../types";
 
@@ -14,8 +12,6 @@ interface Value {
 }
 
 export const NetworksContext = createContext<Value>({} as Value);
-
-const actionId = "network";
 
 export function ProviderNetworks({ children }: { children: ReactNode }) {
   const { data: networks, mutate: mutateNetworks } =
@@ -38,25 +34,6 @@ export function ProviderNetworks({ children }: { children: ReactNode }) {
   };
 
   useRefreshNetwork(mutateNetworks);
-
-  const { setCurrentNetwork } = useCurrentNetwork();
-  useRegisterActions(
-    [
-      {
-        id: actionId,
-        name: "Change network",
-      },
-      ...(networks || []).map((network) => ({
-        id: `${actionId}/${network.name}`,
-        name: network.name,
-        parent: actionId,
-        perform: () => {
-          setCurrentNetwork(network.name);
-        },
-      })),
-    ],
-    [networks, setCurrentNetwork]
-  );
 
   return (
     <NetworksContext.Provider value={value}>

--- a/gui/src/components/ProviderNetworks.tsx
+++ b/gui/src/components/ProviderNetworks.tsx
@@ -3,13 +3,12 @@ import { useRegisterActions } from "kbar";
 import { ReactNode, createContext } from "react";
 
 import { useInvoke } from "../hooks/tauri";
+import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { useRefreshNetwork } from "../hooks/useRefreshNetwork";
 import { Network } from "../types";
 
 interface Value {
   networks?: Network[];
-  currentNetwork?: Network;
-  setCurrentNetwork: (newNetwork: string) => Promise<unknown>;
   setNetworks: (newNetworks: Network[]) => Promise<unknown>;
   resetNetworks: () => Promise<Network[]>;
 }
@@ -21,18 +20,9 @@ const actionId = "network";
 export function ProviderNetworks({ children }: { children: ReactNode }) {
   const { data: networks, mutate: mutateNetworks } =
     useInvoke<Network[]>("networks_get_list");
-  const { data: currentNetwork, mutate: mutateNetwork } = useInvoke<Network>(
-    "networks_get_current"
-  );
 
   const value = {
     networks,
-    currentNetwork,
-    setCurrentNetwork: async (newNetwork: string) => {
-      if (currentNetwork?.name === newNetwork) return;
-
-      await invoke("networks_set_current", { network: newNetwork });
-    },
     setNetworks: async (newNetworks: Network[]) => {
       await invoke("networks_set_list", { newNetworks: newNetworks });
 
@@ -47,11 +37,9 @@ export function ProviderNetworks({ children }: { children: ReactNode }) {
     },
   };
 
-  useRefreshNetwork(() => {
-    mutateNetworks();
-    mutateNetwork();
-  });
+  useRefreshNetwork(mutateNetworks);
 
+  const { setCurrentNetwork } = useCurrentNetwork();
   useRegisterActions(
     [
       {
@@ -62,10 +50,12 @@ export function ProviderNetworks({ children }: { children: ReactNode }) {
         id: `${actionId}/${network.name}`,
         name: network.name,
         parent: actionId,
-        perform: () => value.setCurrentNetwork(network.name),
+        perform: () => {
+          setCurrentNetwork(network.name);
+        },
       })),
     ],
-    [networks, value.setCurrentNetwork]
+    [networks, setCurrentNetwork]
   );
 
   return (

--- a/gui/src/components/ProviderTokensBalances.tsx
+++ b/gui/src/components/ProviderTokensBalances.tsx
@@ -4,7 +4,7 @@ import { ReactNode, createContext } from "react";
 import { useAccount } from "../hooks";
 import { useInvoke } from "../hooks/tauri";
 import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
-import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
+import { useRefreshBalances } from "../hooks/useRefreshBalances";
 import { Address, TokenBalance } from "../types";
 
 interface Value {
@@ -42,7 +42,7 @@ export function ProviderTokensBalances({ children }: { children: ReactNode }) {
     },
   } as Value;
 
-  useRefreshTransactions(mutateBalances);
+  useRefreshBalances(mutateBalances);
 
   useRegisterActions(
     [

--- a/gui/src/components/ProviderTokensBalances.tsx
+++ b/gui/src/components/ProviderTokensBalances.tsx
@@ -3,7 +3,7 @@ import { ReactNode, createContext } from "react";
 
 import { useAccount } from "../hooks";
 import { useInvoke } from "../hooks/tauri";
-import { useNetworks } from "../hooks/useNetworks";
+import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
 import { Address, TokenBalance } from "../types";
 
@@ -18,12 +18,12 @@ const actionId = "token-balances";
 
 export function ProviderTokensBalances({ children }: { children: ReactNode }) {
   const address = useAccount();
-  const { currentNetwork } = useNetworks();
+  const { currentNetwork } = useCurrentNetwork();
   const chainId = currentNetwork?.chain_id;
 
   const { data: balances, mutate: mutateBalances } = useInvoke<
     [Address, string][]
-  >("db_get_erc20_balances", { address });
+  >("db_get_erc20_balances", { chainId, address });
 
   const { mutate: refetchTokensBalances } = useInvoke(
     "alchemy_fetch_balances",

--- a/gui/src/components/ProviderTokensBalances.tsx
+++ b/gui/src/components/ProviderTokensBalances.tsx
@@ -1,0 +1,59 @@
+import { useRegisterActions } from "kbar";
+import { ReactNode, createContext } from "react";
+
+import { useAccount } from "../hooks";
+import { useInvoke } from "../hooks/tauri";
+import { useNetworks } from "../hooks/useNetworks";
+import { useRefreshTransactions } from "../hooks/useRefreshTransactions";
+import { Address, TokenBalance } from "../types";
+
+interface Value {
+  balances: TokenBalance[];
+  refetchBalances: () => Promise<void>;
+}
+
+export const TokensBalancesContext = createContext<Value>({} as Value);
+
+const actionId = "token-balances";
+
+export function ProviderTokensBalances({ children }: { children: ReactNode }) {
+  const address = useAccount();
+  const { currentNetwork } = useNetworks();
+  const chainId = currentNetwork?.chain_id;
+
+  const { data: balances, mutate: mutateBalances } = useInvoke<
+    [Address, string][]
+  >("db_get_erc20_balances", { address });
+
+  const { mutate: refetchTokensBalances } = useInvoke(
+    "alchemy_fetch_balances",
+    { chainId, address },
+    { refreshInterval: 10 * 1000 * 60 }
+  );
+
+  const value = {
+    balances: (balances || [])?.map(([a, c]) => [a, BigInt(c)]),
+    refetchBalances: async () => {
+      refetchTokensBalances();
+    },
+  } as Value;
+
+  useRefreshTransactions(mutateBalances);
+
+  useRegisterActions(
+    [
+      {
+        id: actionId,
+        name: "Refresh tokens balances",
+        perform: () => value.refetchBalances(),
+      },
+    ],
+    [balances, value.refetchBalances]
+  );
+
+  return (
+    <TokensBalancesContext.Provider value={value}>
+      {children}
+    </TokensBalancesContext.Provider>
+  );
+}

--- a/gui/src/components/ProviderTokensBalances.tsx
+++ b/gui/src/components/ProviderTokensBalances.tsx
@@ -28,7 +28,11 @@ export function ProviderTokensBalances({ children }: { children: ReactNode }) {
   const { mutate: refetchTokensBalances } = useInvoke(
     "alchemy_fetch_balances",
     { chainId, address },
-    { refreshInterval: 10 * 1000 * 60 }
+    {
+      refreshInterval: 10 * 1000 * 60,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+    }
   );
 
   const value = {

--- a/gui/src/components/QuickNetworkSelect.tsx
+++ b/gui/src/components/QuickNetworkSelect.tsx
@@ -1,9 +1,11 @@
 import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
 
+import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { useNetworks } from "../hooks/useNetworks";
 
 export function QuickNetworkSelect() {
-  const { networks, currentNetwork, setCurrentNetwork } = useNetworks();
+  const { networks } = useNetworks();
+  const { currentNetwork, setCurrentNetwork } = useCurrentNetwork();
 
   const handleChange = (event: SelectChangeEvent<string>) =>
     setCurrentNetwork(event.target.value);

--- a/gui/src/components/WagmiWrapper.tsx
+++ b/gui/src/components/WagmiWrapper.tsx
@@ -11,7 +11,7 @@ import {
 } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 
-import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
+import { useNetworks } from "../hooks/useNetworks";
 import { Network } from "../types";
 
 interface Props {
@@ -24,15 +24,20 @@ type WagmiConfig = Config<
 >;
 
 export function WagmiWrapper({ children }: Props) {
-  const { currentNetwork } = useCurrentNetwork();
+  const { networks } = useNetworks();
 
-  if (!currentNetwork) return null;
+  if (!networks) return null;
 
   const { publicClient, webSocketPublicClient } = configureChains(
-    [buildChain(currentNetwork)],
-    [jsonRpcProvider({ rpc: () => ({ http: currentNetwork?.http_url }) })]
+    networks.map(buildChain),
+    [
+      jsonRpcProvider({
+        rpc: (chain: Chain) => ({
+          http: networks.find((n) => n.chain_id === chain.id)?.http_url || "",
+        }),
+      }),
+    ]
   );
-
   const config = createConfig({
     publicClient,
     webSocketPublicClient,

--- a/gui/src/components/WagmiWrapper.tsx
+++ b/gui/src/components/WagmiWrapper.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { useEffect, useState } from "react";
 import { FallbackTransport } from "viem";
 import {
   Chain,
@@ -12,7 +11,7 @@ import {
 } from "wagmi";
 import { jsonRpcProvider } from "wagmi/providers/jsonRpc";
 
-import { useInvoke } from "../hooks/tauri";
+import { useCurrentNetwork } from "../hooks/useCurrentNetwork";
 import { Network } from "../types";
 
 interface Props {
@@ -25,25 +24,19 @@ type WagmiConfig = Config<
 >;
 
 export function WagmiWrapper({ children }: Props) {
-  const { data: network } = useInvoke<Network>("networks_get_current");
-  const [config, setConfig] = useState<WagmiConfig>();
+  const { currentNetwork } = useCurrentNetwork();
 
-  useEffect(() => {
-    if (!network) return;
+  if (!currentNetwork) return null;
 
-    const { publicClient, webSocketPublicClient } = configureChains(
-      [buildChain(network)],
-      [jsonRpcProvider({ rpc: () => ({ http: network?.http_url }) })]
-    );
+  const { publicClient, webSocketPublicClient } = configureChains(
+    [buildChain(currentNetwork)],
+    [jsonRpcProvider({ rpc: () => ({ http: currentNetwork?.http_url }) })]
+  );
 
-    const config = createConfig({
-      publicClient,
-      webSocketPublicClient,
-    });
-    setConfig(config);
-  }, [network]);
-
-  if (!config) return null;
+  const config = createConfig({
+    publicClient,
+    webSocketPublicClient,
+  });
 
   return <WagmiConfig config={config}>{children}</WagmiConfig>;
 }

--- a/gui/src/hooks/tauri.ts
+++ b/gui/src/hooks/tauri.ts
@@ -1,13 +1,15 @@
 import { invoke } from "@tauri-apps/api/tauri";
-import useSWR, { SWRResponse } from "swr";
+import useSWR from "swr";
+import type { SWRConfiguration, SWRResponse } from "swr";
 
 type TArgs = Record<string, unknown>;
 
 export const useInvoke = <TResult>(
   command: string,
-  args: TArgs = {}
+  args: TArgs = {},
+  props?: SWRConfiguration
 ): SWRResponse<TResult, unknown> => {
-  return useSWR<TResult>([command, args], invokeFetcher);
+  return useSWR<TResult>([command, args], invokeFetcher, props);
 };
 
 const invokeFetcher = async <TResult>([command, args]: [

--- a/gui/src/hooks/useCurrentNetwork.ts
+++ b/gui/src/hooks/useCurrentNetwork.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+
+import { CurrentNetworkContext } from "../components/ProviderCurrentNetwork";
+
+export function useCurrentNetwork() {
+  return useContext(CurrentNetworkContext);
+}

--- a/gui/src/hooks/useRefreshBalances.ts
+++ b/gui/src/hooks/useRefreshBalances.ts
@@ -1,0 +1,14 @@
+import { listen } from "@tauri-apps/api/event";
+import { useEffect } from "react";
+
+export function useRefreshBalances(callback: () => unknown) {
+  useEffect(() => {
+    const unlisten = listen("balances-updated", () => {
+      callback();
+    });
+
+    return () => {
+      unlisten.then((cb) => cb());
+    };
+  }, [callback]);
+}

--- a/gui/src/hooks/useTokensBalances.ts
+++ b/gui/src/hooks/useTokensBalances.ts
@@ -1,0 +1,7 @@
+import { useContext } from "react";
+
+import { TokensBalancesContext } from "../components/ProviderTokensBalances";
+
+export function useTokensBalances() {
+  return useContext(TokensBalancesContext);
+}

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -63,6 +63,7 @@ export const walletsSchema = z.object({
 });
 
 export type Address = `0x${string}`;
+export type TokenBalance = [Address, bigint];
 export type Wallet = z.infer<typeof walletSchema>;
 export type Wallets = z.infer<typeof walletsSchema>;
 export type Network = z.infer<typeof networkSchema.shape.networks>[number];

--- a/tauri/src/alchemy/commands.rs
+++ b/tauri/src/alchemy/commands.rs
@@ -2,7 +2,6 @@ use super::{Alchemy, Result};
 use crate::types::{ChecksummedAddress, GlobalState};
 
 /// call to fetch balances
-/// TODO: this should also trigger a frontend event to refresh the balances if the request succeeds
 #[tauri::command]
 pub async fn alchemy_fetch_balances(chain_id: u32, address: ChecksummedAddress) -> Result<()> {
     let alchemy = Alchemy::write().await;

--- a/tauri/src/alchemy/mod.rs
+++ b/tauri/src/alchemy/mod.rs
@@ -58,7 +58,6 @@ impl Alchemy {
     }
 
     async fn fetch_balances(&self, chain_id: u32, address: ChecksummedAddress) -> Result<()> {
-        dbg!("fetching balances");
         let settings = Settings::read().await;
         if let (Some(api_key), Some(endpoint)) = (
             settings.inner.alchemy_api_key.as_ref(),

--- a/tauri/src/alchemy/mod.rs
+++ b/tauri/src/alchemy/mod.rs
@@ -80,7 +80,7 @@ impl Alchemy {
             let res = (res["result"]).clone();
             let res: AlchemyResponse = serde_json::from_value(res)?;
             self.db.save_balances(res, chain_id).await?;
-            self.window_snd.send(Notify::TxsUpdated.into())?;
+            self.window_snd.send(Notify::BalancesUpdated.into())?;
         }
 
         Ok(())

--- a/tauri/src/app.rs
+++ b/tauri/src/app.rs
@@ -44,6 +44,7 @@ pub enum Notify {
     NetworkChanged,
     TxsUpdated,
     PeersUpdated,
+    BalancesUpdated,
 }
 
 impl Notify {
@@ -53,6 +54,7 @@ impl Notify {
             Self::NetworkChanged => "network-changed",
             Self::TxsUpdated => "txs-updated",
             Self::PeersUpdated => "peers-updated",
+            Self::BalancesUpdated => "balances-updated",
         }
     }
 }

--- a/tauri/src/block_listener/mod.rs
+++ b/tauri/src/block_listener/mod.rs
@@ -227,6 +227,7 @@ async fn process(
         // otherwise we spam too much during that phase
         if caught_up {
             window_snd.send(Notify::TxsUpdated.into())?;
+            window_snd.send(Notify::BalancesUpdated.into())?;
         }
     }
 

--- a/tauri/src/db/commands.rs
+++ b/tauri/src/db/commands.rs
@@ -26,11 +26,9 @@ pub async fn db_get_contracts(db: tauri::State<'_, DB>) -> Result<Vec<StoredCont
 
 #[tauri::command]
 pub async fn db_get_erc20_balances(
+    chain_id: u32,
     address: Address,
     db: tauri::State<'_, DB>,
 ) -> Result<Vec<(Address, U256)>> {
-    let networks = Networks::read().await;
-
-    let chain_id = networks.get_current_network().chain_id;
     Ok(db.get_balances(chain_id, address).await.unwrap())
 }

--- a/tauri/src/main.rs
+++ b/tauri/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     ))
     .await;
     Foundry::init().await?;
-    Alchemy::init(db.clone()).await;
+    Alchemy::init((db.clone(), app.sender.clone())).await;
 
     // run websockets server loop
     tauri::async_runtime::spawn(async move { ws::ws_server_loop().await });


### PR DESCRIPTION
- Move balances to a react context;
- Request tokens on wallet address change;
- Request tokens on network change;
- Request tokens balances every 10 min;
- Refactor wagmiWrapper to avoid side-effect config, and to be chain-aware. The wagmi wooks now need to receive the chainId, but the wrapper wont rebuild it self on network change;
- Split Networks context into two: Networks and currentNetwork. This is not that important but, splitting those two, makes things a bit more clear. On the frontend they do not really depend from each other, can avoid unnecessary renders and, because we will change the "current network" behavior in the future can be helpful on that effort.