### PR TITLE
using libsodium-sys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,13 +118,13 @@ jobs:
         with:
           releaseId: ${{ needs.setup.outputs.release_id }}
 
-  publish:
-    needs: [setup, extension, app]
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: publish release
-        run: gh release edit ${{ needs.setup.outputs.tag }} --draft=false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # publish:
+  #   needs: [setup, extension, app]
+  #   runs-on: ubuntu-20.04
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #
+  #     - name: publish release
+  #       run: gh release edit ${{ needs.setup.outputs.tag }} --draft=false
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,18 +76,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: install dependencies (ubuntu only)
+      - name: install dependencies (ubuntu)
         if: matrix.platform == 'ubuntu-20.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf libsodium-dev
 
-      - name: install dependencies (windows only)
+      - name: install dependencies (windows)
         if: matrix.platform == 'windows-latest'
         run: |
           C:\msys64\usr\bin\wget.exe https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-msvc.zip
           7z x libsodium-1.0.18-msvc.zip
           Copy-Item -Path libsodium\x64\Release\v142\static\libsodium.lib sodium.lib
+
+      - name: install dependencies (macos)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          brew install libsodium
 
       - name: setup rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,13 +118,13 @@ jobs:
         with:
           releaseId: ${{ needs.setup.outputs.release_id }}
 
-  # publish:
-  #   needs: [setup, extension, app]
-  #   runs-on: ubuntu-20.04
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #
-  #     - name: publish release
-  #       run: gh release edit ${{ needs.setup.outputs.tag }} --draft=false
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish:
+    needs: [setup, extension, app]
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: publish release
+        run: gh release edit ${{ needs.setup.outputs.tag }} --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "iron"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3051,6 +3051,18 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libsodium-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b779387cd56adfbc02ea4a668e704f729be8d6a6abd2c27ca5ee537849a92fd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "walkdir",
 ]
 
 [[package]]
@@ -4672,6 +4684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f51745a213c4a2acabad80cd511e40376996bc83db6ceb4ebc7853d41c597988"
 dependencies = [
  "libc",
+ "libsodium-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "description": "A dev-oriented web3 wallet",
   "scripts": {

--- a/tauri/Cargo.toml
+++ b/tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iron"
-version = "0.2.0"
+version = "0.2.1"
 description = "A Tauri App"
 authors = ["you"]
 license-file = "../LICENSE"
@@ -44,7 +44,7 @@ notify = "6.0.0"
 futures = "0.3.28"
 regex = "1.8.1"
 anyhow = "1.0.71"
-secrets = "1.2.0"
+secrets = { version = "1.2.0", features = ["use-libsodium-sys"] }
 
 [features]
 default = []


### PR DESCRIPTION
this is a temporary change, because libsodium-sys appears to already bundle the statically-linked binaries.
The latest release was apparently using dynamic linking, contrary to what I thought initially