### PR TITLE
Supporting firefox

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,12 @@ jobs:
         run: yarn workspace @iron/extension install
 
       - name: Build extension zip
-        run: yarn workspace @iron/extension build:zip
+        run: yarn workspace @iron/extension release
+        env:
+          EXTENSION_TAG: ${{ needs.setup.outputs.tag }}
 
       - name: Upload to release
-        run: gh release upload ${{ needs.setup.outputs.tag }} ./extension/extension.zip
+        run: gh release upload ${{ needs.setup.outputs.tag }} ./extension/*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tsconfig.tsbuildinfo
 target/
 !migrations/*.sql
 gui/vite.config.ts.timestamp-*
+extension/tmp.*.json

--- a/Justfile
+++ b/Justfile
@@ -11,6 +11,7 @@ build:
 
 dev:
   rm -rf target/debug/db.*
+  (cd ../web3-demo && just dev) &
   yarn run tauri dev --features ${IRON_FEATURES:-debug}
 
 lint:

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -32,5 +32,10 @@
       "matches": ["<all_urls>"],
       "resources": ["inpage.ts"]
     }
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "mpalhas@gmail.com"
+    }
+  }
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -35,7 +35,7 @@
   ],
   "browser_specific_settings": {
     "gecko": {
-      "id": "mpalhas@gmail.com"
+      "id": "iron-wallet@naps62.com"
     }
   }
 }

--- a/extension/options/index.ts
+++ b/extension/options/index.ts
@@ -15,7 +15,7 @@ const saveOptions = () => {
     endpoint: $endpoint.value || defaultSettings.endpoint,
   };
 
-  chrome.storage.sync.set(options, () => {
+  browser.storage.sync.set(options).then(() => {
     // Update status to let user know options were saved.
     $status.textContent = "Options saved. Restart browser to take effect";
     setTimeout(() => {

--- a/extension/package.json
+++ b/extension/package.json
@@ -6,12 +6,12 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn clean && parcel build manifest.json",
-    "build:release": "yarn clean && parcel build manifest.json --no-source-maps",
-    "build:zip": "yarn build:release && zip -r extension.zip ./dist",
+    "build:release": "yarn build:release:chrome && yarn build:release:firefox",
     "dev": "parcel watch manifest.json --no-cache --host localhost",
     "clean": "rm -rf dist .cache",
     "bundle-analyzer": "yarn clean && parcel build manifest.json --no-source-maps --reporter @parcel/reporter-bundle-analyzer && google-chrome-stable parcel-bundle-reports/default.html",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "release": "bash ./release.sh"
   },
   "dependencies": {
     "@metamask/eth-json-rpc-middleware": "https://github.com/MetaMask/eth-json-rpc-middleware#e7a1de5cc9c76f24f436be69850d442c46582975",

--- a/extension/release.sh
+++ b/extension/release.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+patch() {
+  type=$1
+  manifest=$2
+
+  if [[ $type == firefox ]]; then
+    # change background.service_worker into background.scripts
+    jq ".background={scripts: [.background.service_worker]}" -c $manifest > $manifest.tmp
+    mv $manifest.tmp $manifest
+  fi
+}
+
+release() {
+  type=$1
+  # tag comes 1st from CLI arg,
+  # with fallback to $EXTENSION_TAG env variable,
+  # with fallback to "untagged"
+  tag=${2:-${EXTENSION_TAG:-untagged}}
+  dist=dist-${type}
+
+  mkdir -p $dist
+
+  parcel build manifest.json --no-source-maps --dist-dir $dist
+  patch $type $dist/manifest.json
+  zip -r extension-${tag}-${type}.zip $dist
+  rm -rf $manifest $dist
+}
+
+release "chrome" $@
+release "firefox" $@

--- a/extension/settings.ts
+++ b/extension/settings.ts
@@ -1,4 +1,5 @@
 import log from "loglevel";
+import browser from "webextension-polyfill";
 
 export interface Settings {
   logLevel: "info" | "debug" | "warn" | "error";
@@ -11,7 +12,9 @@ export const defaultSettings: Settings = {
 };
 
 export async function loadSettings() {
-  const settings = (await chrome.storage.sync.get(defaultSettings)) as Settings;
+  const settings = (await browser.storage.sync.get(
+    defaultSettings
+  )) as Settings;
   log.setLevel(settings.logLevel);
   return settings;
 }


### PR DESCRIPTION
Fixing #228 

This requires two different tasks:

- [x] replaces `chrome.storage` calls with `browser.storage` from webextensions-polyfill
- [x] update `manifest.browser_specific_settings` (required for debugging extensions on Firefox)
- [x] update `manifest.background`

The last one will have to be handled on the CI, at least until parcel supports firefox extensions ([which it currently doesn't](https://github.com/parcel-bundler/parcel/issues/8785))

some manual testing indicates that simply replacing `{"service_worker": "background.*.ts"}` with `{"scripts": ["background.*.ts"]}` in the output manifest seems to work
chrome and firefox currently require one or the other, there's no version of the manifest that can satisfy both

So editing the workflow to create an additional output zip, with the updated manifest can solve this