### PR TITLE
Refactors some DB functions, and alchemy integration

### DIFF
--- a/tauri/src/alchemy/error.rs
+++ b/tauri/src/alchemy/error.rs
@@ -19,6 +19,12 @@ pub enum Error {
 
     #[error(transparent)]
     Url(#[from] url::ParseError),
+
+    #[error("Unsupported chain id: {0}")]
+    UnsupportedChainId(u32),
+
+    #[error("API Key not found")]
+    NoAPIKey,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tauri/src/alchemy/types.rs
+++ b/tauri/src/alchemy/types.rs
@@ -1,0 +1,22 @@
+use ethers::types::{Address, U256};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Balances {
+    pub address: Address,
+    pub token_balances: Vec<TokenBalance>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TokenBalance {
+    pub contract_address: Address,
+    pub token_balance: U256,
+}
+
+impl From<TokenBalance> for (Address, U256) {
+    fn from(value: TokenBalance) -> Self {
+        (value.contract_address, value.token_balance)
+    }
+}

--- a/tauri/src/block_listener/expanders.rs
+++ b/tauri/src/block_listener/expanders.rs
@@ -1,0 +1,129 @@
+use ethers::{
+    abi::RawLog,
+    contract::EthLogDecode,
+    providers::{Http, Middleware, Provider},
+    types::{Action, Bytes, Call, Create, CreateResult, Log, Res, Trace},
+};
+use futures::future::join_all;
+
+use crate::{
+    foundry::calculate_code_hash,
+    types::{
+        events::{ContractDeployed, ERC20Transfer, ERC721Transfer, Tx},
+        Event,
+    },
+};
+
+pub(super) async fn expand_traces(traces: Vec<Trace>, provider: &Provider<Http>) -> Vec<Event> {
+    let result = traces.into_iter().map(|t| expand_trace(t, provider));
+    join_all(result).await.into_iter().flatten().collect()
+}
+
+pub(super) fn expand_logs(traces: Vec<Log>) -> Vec<crate::types::Event> {
+    traces.into_iter().filter_map(expand_log).collect()
+}
+
+async fn expand_trace(trace: Trace, provider: &Provider<Http>) -> Vec<Event> {
+    match (
+        trace.action.clone(),
+        trace.result.clone(),
+        trace.trace_address.len(),
+    ) {
+        // contract deploys
+        (
+            Action::Create(Create { from, value, .. }),
+            Some(Res::Create(CreateResult { address, .. })),
+            _,
+        ) => {
+            vec![
+                Tx {
+                    hash: trace.transaction_hash.unwrap(),
+                    block_number: trace.block_number,
+                    position: trace.transaction_position,
+                    from,
+                    to: None,
+                    value,
+                    data: Bytes::new(),
+                }
+                .into(),
+                ContractDeployed {
+                    address,
+                    code_hash: provider
+                        .get_code(address, None)
+                        .await
+                        .ok()
+                        .map(|v| calculate_code_hash(&v.to_string()).to_string()),
+                }
+                .into(),
+            ]
+        }
+
+        // TODO: match call input against ERC20 abi
+
+        // top-level trace of a transaction
+        // other regular calls
+        (
+            Action::Call(Call {
+                from,
+                to,
+                value,
+                input,
+                ..
+            }),
+            _,
+            0,
+        ) => vec![Tx {
+            hash: trace.transaction_hash.unwrap(),
+            block_number: trace.block_number,
+            position: trace.transaction_position,
+            from,
+            to: Some(to),
+            value,
+            data: input,
+        }
+        .into()],
+
+        _ => vec![],
+    }
+}
+
+fn expand_log(log: Log) -> Option<Event> {
+    let raw = RawLog::from((log.topics, log.data.to_vec()));
+
+    use crate::abis::{
+        ierc20::{self, IERC20Events},
+        ierc721::{self, IERC721Events},
+    };
+
+    // decode ERC20 calls
+    if let Ok(IERC20Events::TransferFilter(ierc20::TransferFilter { from, to, value })) =
+        IERC20Events::decode_log(&raw)
+    {
+        return Some(
+            ERC20Transfer {
+                from,
+                to,
+                value,
+                contract: log.address,
+            }
+            .into(),
+        );
+    };
+
+    // decode ERC721 calls
+    if let Ok(IERC721Events::TransferFilter(ierc721::TransferFilter { from, to, token_id })) =
+        IERC721Events::decode_log(&raw)
+    {
+        return Some(
+            ERC721Transfer {
+                from,
+                to,
+                token_id,
+                contract: log.address,
+            }
+            .into(),
+        );
+    };
+
+    None
+}

--- a/tauri/src/db/queries.rs
+++ b/tauri/src/db/queries.rs
@@ -20,11 +20,7 @@ pub(super) fn insert_transaction(tx: &events::Tx, chain_id: u32) -> Query {
     .bind(tx.value.to_string())
 }
 
-pub(super) fn insert_contract(
-    tx: &events::ContractDeployed,
-    chain_id: u32,
-    code_hash: Option<String>,
-) -> Query {
+pub(super) fn insert_contract(tx: &events::ContractDeployed, chain_id: u32) -> Query {
     sqlx::query(
         r#" INSERT INTO contracts (address, chain_id, deployed_code_hash)
                         VALUES (?,?,?)
@@ -32,7 +28,7 @@ pub(super) fn insert_contract(
     )
     .bind(format!("0x{:x}", tx.address))
     .bind(chain_id)
-    .bind(code_hash)
+    .bind(tx.code_hash.clone())
 }
 
 /// The horrible return type here can be aliased once `type_alias_impl_trait` is stabilized

--- a/tauri/src/types/mod.rs
+++ b/tauri/src/types/mod.rs
@@ -3,7 +3,7 @@ pub mod events;
 mod global_state;
 
 pub use checksummed_address::ChecksummedAddress;
-pub use events::{Event, Events};
+pub use events::Event;
 pub use global_state::GlobalState;
 
 pub type Json = serde_json::Value;


### PR DESCRIPTION
The DB module was getting a bit of a mess: doing provider requests, as well as receiving alchemy-specific payloads for ERC20 balances

This refactors both of those.

* Alchemy types are now private to the Alchemy module. The `save_balances` function receives a simple tuple vector, which Alchemy needs to convert to itself
* Logic to parse events and possibly do additional provider requests has been moved to the block_listener module, since that'll likely be anvil-only for the time being