### PR TITLE
Creating/updating wallets via json fields instead of direct derivation

### DIFF
--- a/tauri/src/wallets/commands.rs
+++ b/tauri/src/wallets/commands.rs
@@ -1,5 +1,5 @@
 use super::{Result, Wallet, WalletControl, Wallets};
-use crate::types::{ChecksummedAddress, GlobalState};
+use crate::types::{ChecksummedAddress, GlobalState, Json};
 
 /// Lists all wallets
 #[tauri::command]
@@ -31,8 +31,8 @@ pub async fn wallets_set_list(list: Vec<Wallet>) -> Result<()> {
 }
 
 #[tauri::command]
-pub async fn wallets_create(wallet: Wallet) -> Result<()> {
-    Wallets::write().await.create(wallet).await
+pub async fn wallets_create(params: Json) -> Result<()> {
+    Wallets::write().await.create(params).await
 }
 
 #[tauri::command]

--- a/tauri/src/wallets/error.rs
+++ b/tauri/src/wallets/error.rs
@@ -34,6 +34,9 @@ pub enum Error {
 
     #[error("error sending event to window: {0}")]
     WindowSend(#[from] tokio::sync::mpsc::error::SendError<app::Event>),
+
+    #[error("invalid wallet type: {0}")]
+    InvalidWalletType(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/tauri/src/wallets/mod.rs
+++ b/tauri/src/wallets/mod.rs
@@ -16,6 +16,7 @@ pub use error::{Error, Result};
 use serde::Serialize;
 use tokio::sync::mpsc;
 
+use self::wallet::WalletCreate;
 pub use self::{
     json_keystore_wallet::JsonKeystoreWallet,
     plaintext::PlaintextWallet,
@@ -24,7 +25,7 @@ pub use self::{
 use crate::{
     app,
     peers::Peers,
-    types::{ChecksummedAddress, GlobalState},
+    types::{ChecksummedAddress, GlobalState, Json},
 };
 
 /// Maintains a list of Ethereum wallets, including keeping track of the global current wallet &
@@ -92,7 +93,8 @@ impl Wallets {
         Ok(())
     }
 
-    async fn create(&mut self, wallet: Wallet) -> Result<()> {
+    async fn create(&mut self, params: Json) -> Result<()> {
+        let wallet = Wallet::create(params).await?;
         // TODO: ensure no duplicates
         self.wallets.push(wallet);
         self.on_wallet_changed().await?;

--- a/tauri/src/wallets/plaintext.rs
+++ b/tauri/src/wallets/plaintext.rs
@@ -1,12 +1,13 @@
 use std::str::FromStr;
 
+use async_trait::async_trait;
 use coins_bip32::path::DerivationPath;
 use ethers::signers::{coins_bip39::English, MnemonicBuilder, Signer};
 use ethers_core::k256::ecdsa::SigningKey;
 use serde::{Deserialize, Serialize};
 
-use super::{utils, Result, WalletControl};
-use crate::types::ChecksummedAddress;
+use super::{utils, wallet::WalletCreate, Result, Wallet, WalletControl};
+use crate::types::{ChecksummedAddress, Json};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(try_from = "Deserializer", rename_all = "camelCase")]
@@ -19,10 +20,21 @@ pub struct PlaintextWallet {
     current_path: String,
 }
 
-#[async_trait::async_trait]
+#[async_trait]
+impl WalletCreate for PlaintextWallet {
+    async fn create(params: Json) -> Result<Wallet> {
+        Ok(Wallet::Plaintext(serde_json::from_value(params)?))
+    }
+}
+
+#[async_trait]
 impl WalletControl for PlaintextWallet {
     fn name(&self) -> String {
         self.name.clone()
+    }
+
+    async fn update(&mut self, params: Json) -> Result<Wallet> {
+        Ok(Wallet::Plaintext(serde_json::from_value(params)?))
     }
 
     async fn get_current_address(&self) -> ChecksummedAddress {

--- a/tauri/src/wallets/wallet.rs
+++ b/tauri/src/wallets/wallet.rs
@@ -3,13 +3,14 @@ use enum_dispatch::enum_dispatch;
 use ethers_core::k256::ecdsa::SigningKey;
 use serde::{Deserialize, Serialize};
 
-use super::Result;
-use crate::types::ChecksummedAddress;
+use super::{Error, JsonKeystoreWallet, PlaintextWallet, Result};
+use crate::types::{ChecksummedAddress, Json};
 
 #[async_trait]
 #[enum_dispatch(Wallet)]
 pub trait WalletControl: Sync + Send + Deserialize<'static> + Serialize + std::fmt::Debug {
     fn name(&self) -> String;
+    async fn update(&mut self, params: Json) -> Result<Wallet>;
     async fn get_current_address(&self) -> ChecksummedAddress;
     async fn set_current_path(&mut self, path: String) -> Result<()>;
     async fn get_all_addresses(&self) -> Vec<(String, ChecksummedAddress)>;
@@ -20,7 +21,11 @@ pub trait WalletControl: Sync + Send + Deserialize<'static> + Serialize + std::f
     }
 }
 
-use super::{JsonKeystoreWallet, PlaintextWallet};
+/// needs to be a separate trait, because enum_dispatch does not allow for static functions
+#[async_trait]
+pub trait WalletCreate {
+    async fn create(params: Json) -> Result<Wallet>;
+}
 
 #[enum_dispatch]
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -28,4 +33,19 @@ use super::{JsonKeystoreWallet, PlaintextWallet};
 pub enum Wallet {
     Plaintext(PlaintextWallet),
     JsonKeystore(JsonKeystoreWallet),
+}
+
+#[async_trait]
+impl WalletCreate for Wallet {
+    async fn create(params: Json) -> Result<Wallet> {
+        let wallet_type = params["type"].as_str().unwrap_or_default();
+
+        let wallet = match wallet_type {
+            "plaintext" => PlaintextWallet::create(params).await?,
+            "json_keystore" => JsonKeystoreWallet::create(params).await?,
+            _ => return Err(Error::InvalidWalletType(wallet_type.into())),
+        };
+
+        Ok(wallet)
+    }
 }


### PR DESCRIPTION
We need the ability to tweak the create/update process of individual wallets (in anticipation of upcoming HD Wallets)
This change moves the deserialization process down to the `Wallet` manager instead of being done implicitly by tauri commands