### PR TITLE
Paginated transaction list

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -27,6 +27,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.1",
+    "react-infinite-scroller": "^1.2.6",
     "react-query": "^3.39.3",
     "swr": "^2.1.1",
     "truncate-eth-address": "^1.0.2",
@@ -45,6 +46,7 @@
     "@types/node": "^18.7.10",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.10",
+    "@types/react-infinite-scroller": "^1.2.3",
     "@vitejs/plugin-react": "^3.0.0",
     "jsdom": "^21.1.1",
     "vitest": "^0.29.8"

--- a/gui/src/components/Txs.tsx
+++ b/gui/src/components/Txs.tsx
@@ -27,7 +27,7 @@ export function Txs() {
 
   const loadMore = () => {
     let pagination: Pagination = {};
-    let last = pages?.at(-1)?.pagination;
+    const last = pages?.at(-1)?.pagination;
     if (!!last) {
       pagination = last;
       pagination.page = (pagination.page || 0) + 1;

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -141,3 +141,15 @@ export interface Tx {
   position: number;
   status: number;
 }
+
+export interface Pagination {
+  page?: number;
+  page_size?: number;
+}
+
+export interface Paginated<T> {
+  pagination: Pagination;
+  items: T[];
+  last: boolean;
+  total: number;
+}

--- a/tauri/src/db/commands.rs
+++ b/tauri/src/db/commands.rs
@@ -1,6 +1,6 @@
 use ethers::types::{Address, U256};
 
-use super::Result;
+use super::{Paginated, Pagination, Result};
 use crate::db::{StoredContract, DB};
 use crate::types::events::Tx;
 
@@ -8,9 +8,13 @@ use crate::types::events::Tx;
 pub async fn db_get_transactions(
     address: Address,
     chain_id: u32,
+    pagination: Option<Pagination>,
     db: tauri::State<'_, DB>,
-) -> Result<Vec<Tx>> {
-    Ok(db.get_transactions(chain_id, address).await.unwrap())
+) -> Result<Paginated<Tx>> {
+    Ok(db
+        .get_transactions(chain_id, address, pagination.unwrap_or_default())
+        .await
+        .unwrap())
 }
 
 #[tauri::command]

--- a/tauri/src/db/mod.rs
+++ b/tauri/src/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 mod error;
+mod pagination;
 mod queries;
 
 use std::{path::PathBuf, str::FromStr};
@@ -11,7 +12,10 @@ use sqlx::{
     Row,
 };
 
-pub use self::error::{Error, Result};
+pub use self::{
+    error::{Error, Result},
+    pagination::{Paginated, Pagination},
+};
 use crate::types::{events::Tx, Event};
 
 #[derive(Debug, Clone)]
@@ -138,22 +142,45 @@ impl DB {
         Ok(())
     }
 
-    async fn get_transactions(&self, chain_id: u32, from_or_to: Address) -> Result<Vec<Tx>> {
-        let res: Vec<_> = sqlx::query(
+    async fn get_transactions(
+        &self,
+        chain_id: u32,
+        from_or_to: Address,
+        pagination: Pagination,
+    ) -> Result<Paginated<Tx>> {
+        let items: Vec<_> = sqlx::query(
             r#" SELECT *
             FROM transactions
             WHERE chain_id = ?
             AND (from_address = ? or to_address = ?) COLLATE NOCASE
-            ORDER BY block_number DESC, position DESC"#,
+            ORDER BY block_number DESC, position DESC
+            LIMIT ? OFFSET ?"#,
         )
         .bind(chain_id)
         .bind(format!("0x{:x}", from_or_to))
         .bind(format!("0x{:x}", from_or_to))
+        .bind(pagination.page_size)
+        .bind(pagination.offset())
         .map(|row| Tx::try_from(&row).unwrap())
         .fetch_all(self.pool())
         .await?;
 
-        Ok(res)
+        let total: u32 = sqlx::query(
+            r#"
+            SELECT COUNT(*) as total
+            FROM transactions
+            WHERE chain_id = ?
+            AND (from_address = ? or to_address = ?) COLLATE NOCASE
+            "#,
+        )
+        .bind(chain_id)
+        .bind(format!("0x{:x}", from_or_to))
+        .bind(format!("0x{:x}", from_or_to))
+        .map(|row| row.get("total"))
+        .fetch_one(self.pool())
+        .await?;
+
+        Ok(Paginated::new(items, pagination, total))
     }
 
     pub async fn get_contracts(&self, chain_id: u32) -> Result<Vec<StoredContract>> {

--- a/tauri/src/db/pagination.rs
+++ b/tauri/src/db/pagination.rs
@@ -1,0 +1,48 @@
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Pagination {
+    #[serde(default)]
+    pub page: u32,
+    #[serde(default = "default_page_size")]
+    pub page_size: u32,
+}
+
+pub fn default_page_size() -> u32 {
+    20
+}
+
+impl Pagination {
+    pub fn offset(&self) -> u32 {
+        self.page_size * self.page
+    }
+}
+
+impl Default for Pagination {
+    fn default() -> Self {
+        Self {
+            page: 0,
+            page_size: 20,
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Paginated<T> {
+    pub pagination: Pagination,
+    pub items: Vec<T>,
+    pub last: bool,
+    pub total: u32,
+}
+
+impl<T> Paginated<T> {
+    pub fn new(items: Vec<T>, pagination: Pagination, total: u32) -> Self {
+        let last = pagination.offset() + items.len() as u32 >= total;
+        Self {
+            items,
+            pagination,
+            total,
+            last,
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,6 +2777,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-infinite-scroller@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@types/react-infinite-scroller/-/react-infinite-scroller-1.2.3.tgz#b8dcb0e5762c3f79cc92e574d2c77402524cab71"
+  integrity sha512-l60JckVoO+dxmKW2eEG7jbliEpITsTJvRPTe97GazjF5+ylagAuyYdXl8YY9DQsTP9QjhqGKZROknzgscGJy0A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-is@^16.7.1 || ^17.0.0":
   version "17.0.4"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.4.tgz#3cccd02851f7f7a75b21d6e922da26bc7f8f44ad"
@@ -6983,7 +6990,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
 
-prop-types@^15.6.2, prop-types@^15.8.1:
+prop-types@^15.5.8, prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7116,6 +7123,13 @@ react-hook-form@^7.43.1:
   version "7.43.5"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.43.5.tgz#b320405594f1506d8d57b954383166d4ff563778"
   integrity sha512-YcaXhuFHoOPipu5pC7ckxrLrialiOcU91pKu8P+isAcXZyMgByUK9PkI9j5fENO4+6XU5PwWXRGMIFlk9u9UBQ==
+
+react-infinite-scroller@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz#8b80233226dc753a597a0eb52621247f49b15f18"
+  integrity sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==
+  dependencies:
+    prop-types "^15.5.8"
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
Since mainnet history may be too big, we need pagination in the transactions list and queries, otherwise the UI blocks for too long (e.g.: the default test account has 460 mainnet transactions)