### PR TITLE
Change near 0 amounts to < 0.001

### DIFF
--- a/gui/src/components/BalancesList.tsx
+++ b/gui/src/components/BalancesList.tsx
@@ -84,9 +84,10 @@ interface BalanceItemProps {
 }
 
 function BalanceItem({ balance, decimals, symbol }: BalanceItemProps) {
+  const minimum = 0.001;
   // Some tokens respond with 1 decimals, that breaks this truncatedBalance without the Math.ceil
   const truncatedBalance =
-    balance - (balance % BigInt(Math.ceil(0.001 * 10 ** decimals)));
+    balance - (balance % BigInt(Math.ceil(minimum * 10 ** decimals)));
 
   return (
     <ListItem>
@@ -97,7 +98,9 @@ function BalanceItem({ balance, decimals, symbol }: BalanceItemProps) {
       </ListItemAvatar>
       <ListItemText secondary={symbol}>
         <CopyToClipboard label={balance.toString()}>
-          {formatUnits(truncatedBalance, decimals)}
+          {truncatedBalance > 0
+            ? formatUnits(truncatedBalance, decimals)
+            : `< ${minimum}`}
         </CopyToClipboard>
       </ListItemText>
     </ListItem>


### PR DESCRIPTION
When tokens have a balance < 0.001, this would show as 0 in the UI, which would be confusing since we have a default setting of hiding tokens with zero balance

This change makes it more explicit that the actual balance is not zero, but close to it

![image](https://github.com/iron-wallet/iron/assets/283819/46f0bfcc-b6fa-4edf-b9a4-cd9ed436bb07)
