### PR TITLE
Stopping event propagation in modals and contextmenus

### DIFF
--- a/gui/src/components/ContextMenu.tsx
+++ b/gui/src/components/ContextMenu.tsx
@@ -51,22 +51,24 @@ export function ContextMenu({ children, sx, copy, explorer, actions }: Props) {
   const onContextCopy = () => copyToClipboard(copy);
 
   const onCopyText = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     event.preventDefault();
     copyToClipboard(copy);
   };
 
   const onCloseMenu = () => setContextMenu(null);
 
-  const onContextMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
+  const onContextMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
     setContextMenu(null);
 
     setContextMenu(
       contextMenu === null
         ? {
-            target: e.currentTarget,
-            mouseX: e.clientX + 2,
-            mouseY: e.clientY - 6,
+            target: event.currentTarget,
+            mouseX: event.clientX + 2,
+            mouseY: event.clientY - 6,
           }
         : null
     );
@@ -76,6 +78,7 @@ export function ContextMenu({ children, sx, copy, explorer, actions }: Props) {
     e: MouseEvent<HTMLAnchorElement>,
     action: () => unknown
   ) => {
+    e.stopPropagation();
     e.preventDefault();
     setContextMenu(null);
     action();

--- a/gui/src/components/Modal.tsx
+++ b/gui/src/components/Modal.tsx
@@ -15,6 +15,10 @@ export function Modal({ children, sx, ...props }: Props) {
       {...props}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
     >
       <Paper sx={style({ sx })}>{children}</Paper>
     </MuiModal>

--- a/gui/src/components/Txs.tsx
+++ b/gui/src/components/Txs.tsx
@@ -1,5 +1,8 @@
 import { CallMade, CallReceived, NoteAdd } from "@mui/icons-material";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Badge,
   Box,
   CircularProgress,
@@ -72,13 +75,13 @@ export function Txs() {
         hasMore={!pages.at(-1)?.last}
         loader={loader}
       >
-        <List key={"list"}>
+        <Stack>
           {pages.flatMap((page) =>
             page.items.map((tx) => (
               <Receipt account={account} tx={tx} key={tx.hash} />
             ))
           )}
-        </List>
+        </Stack>
       </InfiniteScroll>
     </Panel>
   );
@@ -93,33 +96,36 @@ function Receipt({ account, tx }: ReceiptProps) {
   const value = BigInt(tx.value);
 
   return (
-    <ListItem>
-      <ListItemAvatar>
-        <Icon {...{ tx, account }} />
-      </ListItemAvatar>
-      <Box sx={{ flexGrow: 1 }}>
-        <Stack>
-          <Stack direction="row" spacing={1}>
-            <AddressView address={tx.from} /> <span>→</span>
-            {tx.to ? (
-              <AddressView address={tx.to} />
-            ) : (
-              <Typography component="span">Contract Deploy</Typography>
-            )}
+    <Accordion>
+      <AccordionSummary>
+        <ListItemAvatar>
+          <Icon {...{ tx, account }} />
+        </ListItemAvatar>
+        <Box sx={{ flexGrow: 1 }}>
+          <Stack>
+            <Stack direction="row" spacing={1}>
+              <AddressView address={tx.from} /> <span>→</span>
+              {tx.to ? (
+                <AddressView address={tx.to} />
+              ) : (
+                <Typography component="span">Contract Deploy</Typography>
+              )}
+            </Stack>
+            <Typography variant="caption" fontSize="xl">
+              Block #{tx.blockNumber?.toLocaleString()}
+            </Typography>
           </Stack>
-          <Typography variant="caption" fontSize="xl">
-            Block #{tx.blockNumber?.toLocaleString()}
-          </Typography>
-        </Stack>
-      </Box>
-      <Box>
-        {value > 0n && (
-          <ContextMenu copy={value.toString()}>
-            {formatEther(value)} Ξ
-          </ContextMenu>
-        )}
-      </Box>
-    </ListItem>
+        </Box>
+        <Box>
+          {value > 0n && (
+            <ContextMenu copy={value.toString()}>
+              {formatEther(value)} Ξ
+            </ContextMenu>
+          )}
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails>TODO</AccordionDetails>
+    </Accordion>
   );
 }
 


### PR DESCRIPTION
This prevents some weird behaviours when clicking on context menus that exist inside accordion headers