### PR TITLE
Hiding crypto icons for now

### DIFF
--- a/gui/src/components/BalancesList.tsx
+++ b/gui/src/components/BalancesList.tsx
@@ -6,7 +6,8 @@ import {
   ListItemText,
   Stack,
 } from "@mui/material";
-import { formatUnits } from "viem";
+import truncateEthAddress from "truncate-eth-address";
+import { Address, formatUnits } from "viem";
 
 import { useInvoke } from "../hooks";
 import { useBalances, useNetworks } from "../store";
@@ -54,6 +55,7 @@ function BalancesERC20() {
       {filteredBalances.map(({ contract, balance, metadata }) => (
         <BalanceERC20
           key={contract}
+          contract={contract}
           balance={BigInt(balance)}
           decimals={metadata.decimals}
           symbol={metadata.symbol}
@@ -64,26 +66,41 @@ function BalancesERC20() {
 }
 
 function BalanceERC20({
+  contract,
   balance,
   decimals,
   symbol,
 }: {
+  contract: Address;
   balance: bigint;
   decimals: number;
   symbol: string;
 }) {
   if (!symbol || !decimals) return null;
 
-  return <BalanceItem balance={balance} decimals={decimals} symbol={symbol} />;
+  return (
+    <BalanceItem
+      contract={contract}
+      balance={balance}
+      decimals={decimals}
+      symbol={symbol}
+    />
+  );
 }
 
 interface BalanceItemProps {
+  contract?: Address;
   balance: bigint;
   decimals: number;
   symbol: string;
 }
 
-function BalanceItem({ balance, decimals, symbol }: BalanceItemProps) {
+function BalanceItem({
+  balance,
+  decimals,
+  symbol,
+  contract,
+}: BalanceItemProps) {
   const minimum = 0.001;
   // Some tokens respond with 1 decimals, that breaks this truncatedBalance without the Math.ceil
   const truncatedBalance =
@@ -96,7 +113,11 @@ function BalanceItem({ balance, decimals, symbol }: BalanceItemProps) {
           <IconCrypto ticker={symbol} />
         </Avatar>
       </ListItemAvatar>
-      <ListItemText secondary={symbol}>
+      <ListItemText
+        secondary={`${symbol} ${
+          contract && `(${truncateEthAddress(contract)})`
+        }`}
+      >
         <CopyToClipboard label={balance.toString()}>
           {truncatedBalance > 0
             ? formatUnits(truncatedBalance, decimals)

--- a/gui/src/components/IconCrypto.tsx
+++ b/gui/src/components/IconCrypto.tsx
@@ -9,13 +9,14 @@ interface Props {
 const urlFor = (ticker: string, type: "color" | "black" | "white") =>
   `/cryptocurrency-icons/${type}/${ticker.toLowerCase()}.svg`;
 
-export function IconCrypto({ ticker }: Props) {
+export function IconCrypto({}: Props) {
   const themeMode = useTheme((s) => s.theme.palette.mode);
 
   const mode = themeMode === "dark" ? "black" : "white";
 
   const [error, setError] = useState(false);
-  const [src, setSrc] = useState<string | undefined>(urlFor(ticker, "color"));
+  // const [src, setSrc] = useState<string | undefined>(urlFor(ticker, "color"));
+  const [src, setSrc] = useState<string | undefined>(urlFor("generic", mode));
   const onError = () => setError(true);
 
   useEffect(() => {


### PR DESCRIPTION
We're showing icons based solely on the token name, which may be a security issue since any random token may set arbitrary names.
Before shipping this feature, I'm hiding icons temporarily to better think on how to approach this

PS: The same issue arguably exists for token names. I'll handle that for now by showing the contract address (which at least makes it easier to verify), although a long-term solution will always be to create a denylist of spam tokens