### PR TITLE
Fetching ERC20 metadata on anvil

### DIFF
--- a/gui/src/components/BalancesList.tsx
+++ b/gui/src/components/BalancesList.tsx
@@ -49,7 +49,6 @@ function BalancesERC20() {
   const filteredBalances = (balances || []).filter(
     (token) => !settings?.hideEmptyTokens || BigInt(token.balance) > 0
   );
-  console.log(filteredBalances);
 
   return (
     <>
@@ -106,7 +105,6 @@ function BalanceItem({
   // Some tokens respond with 1 decimals, that breaks this truncatedBalance without the Math.ceil
   const truncatedBalance =
     balance - (balance % BigInt(Math.ceil(minimum * 10 ** decimals)));
-  console.log(balance);
 
   return (
     <ListItem>

--- a/gui/src/components/BalancesList.tsx
+++ b/gui/src/components/BalancesList.tsx
@@ -49,6 +49,7 @@ function BalancesERC20() {
   const filteredBalances = (balances || []).filter(
     (token) => !settings?.hideEmptyTokens || BigInt(token.balance) > 0
   );
+  console.log(filteredBalances);
 
   return (
     <>
@@ -105,6 +106,7 @@ function BalanceItem({
   // Some tokens respond with 1 decimals, that breaks this truncatedBalance without the Math.ceil
   const truncatedBalance =
     balance - (balance % BigInt(Math.ceil(minimum * 10 ** decimals)));
+  console.log(balance);
 
   return (
     <ListItem>


### PR DESCRIPTION
This was an oversight. We broke erc20 metadata for anvil when we added alchemy support. As a result, tokenns were not showing for anvil chains
This adds it back