### PR TITLE
Refactor SendTransaction / SignMessage

### DIFF
--- a/crates/rpc/src/send_transaction.rs
+++ b/crates/rpc/src/send_transaction.rs
@@ -3,23 +3,119 @@ use std::str::FromStr;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::{
     prelude::*,
-    signers::Wallet,
+    signers,
     types::{serde_helpers::StringifiedNumeric, transaction::eip2718::TypedTransaction},
 };
 use iron_dialogs::{Dialog, DialogMsg};
+use iron_networks::Network;
+use iron_wallets::{Wallet, WalletControl};
 
 use super::{Error, Result};
 
-#[derive(Default)]
-pub struct SendTransaction {
-    pub dialog: bool,
+/// Orchestrates the signing of a transaction
+/// Takes references to both the wallet and network where this
+pub struct SendTransaction<'a> {
+    pub wallet: &'a Wallet,
+    pub wallet_path: String,
+    pub network: &'a Network,
     pub request: TypedTransaction,
-    pub signer: Option<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
-    skip_dialog: bool,
+    pub signer: Option<SignerMiddleware<Provider<Http>, signers::Wallet<SigningKey>>>,
 }
 
-impl SendTransaction {
-    pub fn set_params(&mut self, params: serde_json::Value) -> &mut Self {
+impl<'a> SendTransaction<'a> {
+    pub fn build() -> SendTransactionBuilder<'a> {
+        Default::default()
+    }
+
+    pub async fn estimate_gas(&mut self) -> &mut SendTransaction<'a> {
+        self.build_signer().await;
+
+        // TODO: we're defaulting to 1_000_000 gas cost if estimation fails
+        // estimation failing means the tx will faill anyway, so this is fine'ish
+        // but can probably be improved a lot in the future
+        let gas_limit = self
+            .signer
+            .as_ref()
+            .unwrap()
+            .estimate_gas(&self.request, None)
+            .await
+            .unwrap_or(1_000_000.into());
+
+        self.request.set_gas(gas_limit * 120 / 100);
+        self
+    }
+
+    pub async fn finish(&mut self) -> Result<PendingTransaction<'_, Http>> {
+        self.build_signer().await;
+
+        if !self.network.is_dev() && self.wallet.is_dev() {
+            self.spawn_dialog().await?;
+        }
+        self.send().await
+    }
+
+    async fn spawn_dialog(&mut self) -> Result<()> {
+        let params = serde_json::to_value(&self.request).unwrap();
+
+        let dialog = Dialog::new("tx-review", params);
+        dialog.open().await?;
+
+        match dialog.recv().await {
+            // TODO: in the future, send json values here to override params
+            Some(DialogMsg::Accept(_response)) => Ok(()),
+
+            _ =>
+            // TODO: what's the appropriate error to return here?
+            // or should we return Ok(_)? Err(_) seems to close the ws connection
+            {
+                Err(Error::TxDialogRejected)
+            }
+        }
+    }
+
+    async fn build_signer(&mut self) {
+        if self.signer.is_some() {
+            let signer: signers::Wallet<SigningKey> = self
+                .wallet
+                .build_signer(self.network.chain_id, &self.wallet_path)
+                .await
+                .unwrap();
+            self.signer = Some(SignerMiddleware::new(self.network.get_provider(), signer));
+        }
+    }
+
+    async fn send(&mut self) -> Result<PendingTransaction<'_, Http>> {
+        let signer = self.signer.as_ref().unwrap();
+
+        Ok(signer.send_transaction(self.request.clone(), None).await?)
+    }
+}
+
+#[derive(Default)]
+pub struct SendTransactionBuilder<'a> {
+    pub wallet: Option<&'a Wallet>,
+    pub wallet_path: Option<String>,
+    pub network: Option<&'a Network>,
+    pub request: TypedTransaction,
+}
+
+impl<'a> SendTransactionBuilder<'a> {
+    pub fn set_wallet(mut self, wallet: &'a Wallet) -> SendTransactionBuilder<'a> {
+        self.wallet = Some(wallet);
+        self
+    }
+
+    pub fn set_wallet_path(mut self, wallet_path: String) -> SendTransactionBuilder<'a> {
+        self.wallet_path = Some(wallet_path);
+        self
+    }
+
+    pub fn set_network(mut self, network: &'a Network) -> SendTransactionBuilder<'a> {
+        self.network = Some(network);
+        self
+    }
+
+    pub fn set_request(mut self, params: serde_json::Value) -> SendTransactionBuilder<'a> {
         // TODO: why is this an array?
         let params = if params.is_array() {
             &params.as_array().unwrap()[0]
@@ -47,72 +143,13 @@ impl SendTransaction {
         self
     }
 
-    pub fn set_chain_id(&mut self, chain_id: u32) -> &mut Self {
-        self.request.set_chain_id(chain_id);
-        self
-    }
-
-    pub fn set_signer(
-        &mut self,
-        signer: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
-    ) -> &mut Self {
-        self.signer = Some(signer);
-        self
-    }
-
-    pub async fn estimate_gas(&mut self) -> &mut Self {
-        // TODO: we're defaulting to 1_000_000 gas cost if estimation fails
-        // estimation failing means the tx will faill anyway, so this is fine'ish
-        // but can probably be improved a lot in the future
-        let gas_limit = self
-            .signer
-            .as_ref()
-            .unwrap()
-            .estimate_gas(&self.request, None)
-            .await
-            .unwrap_or(1_000_000.into());
-
-        self.request.set_gas(gas_limit * 120 / 100);
-        self
-    }
-
-    pub fn skip_dialog(&mut self) -> &mut Self {
-        self.skip_dialog = true;
-        self
-    }
-
-    pub async fn finish(&mut self) -> Result<PendingTransaction<'_, Http>> {
-        if !self.skip_dialog {
-            self.spawn_dialog().await?;
+    pub fn build(self) -> SendTransaction<'a> {
+        SendTransaction {
+            wallet: self.wallet.unwrap(),
+            wallet_path: self.wallet_path.unwrap(),
+            network: self.network.unwrap(),
+            request: self.request,
+            signer: None,
         }
-        self.send().await
-    }
-
-    async fn spawn_dialog(&mut self) -> Result<()> {
-        let params = serde_json::to_value(&self.request).unwrap();
-
-        let dialog = Dialog::new("tx-review", params);
-        dialog.open().await?;
-
-        match dialog.recv().await {
-            // TODO: in the future, send json values here to override params
-            Some(DialogMsg::Accept(_response)) => Ok(()),
-
-            _ =>
-            // TODO: what's the appropriate error to return here?
-            // or should we return Ok(_)? Err(_) seems to close the ws connection
-            {
-                Err(Error::TxDialogRejected)
-            }
-        }
-    }
-
-    async fn send(&mut self) -> Result<PendingTransaction<'_, Http>> {
-        Ok(self
-            .signer
-            .as_ref()
-            .unwrap()
-            .send_transaction(self.request.clone(), None)
-            .await?)
     }
 }

--- a/crates/rpc/src/sign_message.rs
+++ b/crates/rpc/src/sign_message.rs
@@ -1,61 +1,39 @@
 use std::str::FromStr;
 
+use ethers::signers::Signer;
 use ethers::{
     core::k256::ecdsa::SigningKey,
     prelude::SignerMiddleware,
-    providers::{Http, Middleware, Provider},
-    signers::{Signer, Wallet},
-    types::{transaction::eip712, Address, Bytes, Signature},
+    providers::{Http, Middleware as _, Provider},
+    signers,
+    types::{transaction::eip712, Bytes, Signature},
 };
 use iron_dialogs::{Dialog, DialogMsg};
+use iron_networks::Network;
+use iron_wallets::{Wallet, WalletControl};
 use serde::Serialize;
 
 use super::{Error, Result};
 
-#[derive(Default)]
-pub struct SignMessage {
-    pub dialog: bool,
-    pub signer: Option<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
-    address: Option<Address>,
-    skip_dialog: bool,
-    data: Option<Data>,
+type Middleware = SignerMiddleware<Provider<Http>, signers::Wallet<SigningKey>>;
+
+/// Orchestrates message signing
+/// Takes references to both the wallet and network
+pub struct SignMessage<'a> {
+    pub wallet: &'a Wallet,
+    pub wallet_path: String,
+    pub network: &'a Network,
+    data: Data,
 }
 
-impl SignMessage {
-    pub fn build_from_string(msg: String) -> Self {
-        Self {
-            data: Some(Data::Raw(msg)),
-            ..Default::default()
-        }
-    }
-
-    pub fn build_from_typed_data(data: eip712::TypedData) -> Self {
-        Self {
-            data: Some(Data::Typed(data)),
-            ..Default::default()
-        }
-    }
-
-    pub fn set_address(&mut self, addr: Address) -> &mut Self {
-        self.address = Some(addr);
-        self
-    }
-
-    pub fn set_signer(
-        &mut self,
-        signer: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
-    ) -> &mut Self {
-        self.signer = Some(signer);
-        self
-    }
-
-    pub fn skip_dialog(&mut self) -> &mut Self {
-        self.skip_dialog = true;
-        self
+impl<'a> SignMessage<'a> {
+    pub fn build() -> SignMessageBuilder<'a> {
+        Default::default()
     }
 
     pub async fn finish(&mut self) -> Result<Signature> {
-        if !self.skip_dialog {
+        let skip_dialog = self.network.is_dev() && self.wallet.is_dev();
+        if !skip_dialog {
             self.spawn_dialog().await?;
         }
         self.sign().await
@@ -80,18 +58,25 @@ impl SignMessage {
     }
 
     pub async fn sign(&mut self) -> Result<Signature> {
-        let signer = self.signer.as_ref().unwrap();
+        let signer = self.build_signer().await;
 
         match self.data {
-            Some(Data::Raw(ref msg)) => {
+            Data::Raw(ref msg) => {
                 let bytes = Bytes::from_str(msg).unwrap();
-                Ok(signer.sign(bytes, &self.address.unwrap()).await?)
+                Ok(signer.sign(bytes, &signer.address()).await?)
             }
-            Some(Data::Typed(ref data)) => {
-                Ok(signer.signer().sign_typed_data(&data.clone()).await?)
-            }
-            None => Err(Error::SignatureRejected),
+            Data::Typed(ref data) => Ok(signer.signer().sign_typed_data(&data.clone()).await?),
         }
+    }
+
+    async fn build_signer(&self) -> Middleware {
+        let signer: signers::Wallet<SigningKey> = self
+            .wallet
+            .build_signer(self.network.chain_id, &self.wallet_path)
+            .await
+            .unwrap();
+
+        SignerMiddleware::new(self.network.get_provider(), signer)
     }
 }
 
@@ -99,4 +84,50 @@ impl SignMessage {
 enum Data {
     Raw(String),
     Typed(eip712::TypedData),
+}
+
+#[derive(Default)]
+pub struct SignMessageBuilder<'a> {
+    pub wallet: Option<&'a Wallet>,
+    pub wallet_path: Option<String>,
+    pub network: Option<&'a Network>,
+    data: Option<Data>,
+}
+
+impl<'a> SignMessageBuilder<'a> {
+    pub fn set_wallet(mut self, wallet: &'a Wallet) -> SignMessageBuilder<'a> {
+        self.wallet = Some(wallet);
+        self
+    }
+
+    pub fn set_wallet_path(mut self, wallet_path: String) -> SignMessageBuilder<'a> {
+        self.wallet_path = Some(wallet_path);
+        self
+    }
+
+    pub fn set_network(mut self, network: &'a Network) -> SignMessageBuilder<'a> {
+        self.network = Some(network);
+        self
+    }
+
+    pub fn set_string_data(mut self, msg: String) -> SignMessageBuilder<'a> {
+        self.data = Some(Data::Raw(msg));
+        self
+    }
+
+    pub fn set_typed_data(mut self, data: eip712::TypedData) -> SignMessageBuilder<'a> {
+        self.data = Some(Data::Typed(data));
+        self
+    }
+
+    pub fn build(self) -> SignMessage<'a> {
+        tracing::debug!("building SendTransaction");
+
+        SignMessage {
+            wallet: self.wallet.unwrap(),
+            wallet_path: self.wallet_path.unwrap(),
+            network: self.network.unwrap(),
+            data: self.data.unwrap(),
+        }
+    }
 }

--- a/crates/wallets/src/hd_wallet.rs
+++ b/crates/wallets/src/hd_wallet.rs
@@ -90,7 +90,7 @@ impl WalletControl for HDWallet {
     }
 
     async fn build_signer(&self, chain_id: u32, path: &str) -> Result<signers::Wallet<SigningKey>> {
-        if !self.addresses.iter().any(|(p, _)| p == &path) {
+        if !self.addresses.iter().any(|(p, _)| p == path) {
             return Err(Error::InvalidKey(path.to_string()));
         }
 
@@ -102,7 +102,7 @@ impl WalletControl for HDWallet {
         let mnemonic = mnemonic_from_secret(&secret);
         let signer = MnemonicBuilder::<English>::default()
             .phrase(mnemonic.as_str())
-            .derivation_path(&path)?
+            .derivation_path(path)?
             .build()?;
 
         Ok(signer.with_chain_id(chain_id))

--- a/crates/wallets/src/hd_wallet.rs
+++ b/crates/wallets/src/hd_wallet.rs
@@ -74,6 +74,10 @@ impl WalletControl for HDWallet {
         self.current.1.clone()
     }
 
+    fn get_current_path(&self) -> String {
+        self.current.0.clone()
+    }
+
     async fn set_current_path(&mut self, path: String) -> Result<()> {
         self.current = self
             .addresses
@@ -85,7 +89,11 @@ impl WalletControl for HDWallet {
         Ok(())
     }
 
-    async fn build_signer(&self, chain_id: u32) -> Result<signers::Wallet<SigningKey>> {
+    async fn build_signer(&self, chain_id: u32, path: &str) -> Result<signers::Wallet<SigningKey>> {
+        if !self.addresses.iter().any(|(p, _)| p == &path) {
+            return Err(Error::InvalidKey(path.to_string()));
+        }
+
         self.unlock().await?;
 
         let secret = self.secret.read().await;
@@ -94,6 +102,7 @@ impl WalletControl for HDWallet {
         let mnemonic = mnemonic_from_secret(&secret);
         let signer = MnemonicBuilder::<English>::default()
             .phrase(mnemonic.as_str())
+            .derivation_path(&path)?
             .build()?;
 
         Ok(signer.with_chain_id(chain_id))

--- a/crates/wallets/src/json_keystore_wallet.rs
+++ b/crates/wallets/src/json_keystore_wallet.rs
@@ -63,11 +63,19 @@ impl WalletControl for JsonKeystoreWallet {
         address.into()
     }
 
+    fn get_current_path(&self) -> String {
+        self.file.to_string_lossy().to_string()
+    }
+
     async fn set_current_path(&mut self, _path: String) -> Result<()> {
         Ok(())
     }
 
-    async fn build_signer(&self, chain_id: u32) -> Result<signers::Wallet<SigningKey>> {
+    async fn build_signer(
+        &self,
+        chain_id: u32,
+        _path: &str,
+    ) -> Result<signers::Wallet<SigningKey>> {
         self.unlock().await?;
 
         let secret = self.secret.read().await;

--- a/crates/wallets/src/plaintext.rs
+++ b/crates/wallets/src/plaintext.rs
@@ -38,7 +38,11 @@ impl WalletControl for PlaintextWallet {
     }
 
     async fn get_current_address(&self) -> ChecksummedAddress {
-        self.build_signer(1).await.unwrap().address().into()
+        self.build_current_signer(1).await.unwrap().address().into()
+    }
+
+    fn get_current_path(&self) -> String {
+        self.current_path.clone()
     }
 
     async fn set_current_path(&mut self, path: String) -> Result<()> {
@@ -53,7 +57,13 @@ impl WalletControl for PlaintextWallet {
         }
     }
 
-    async fn build_signer(&self, chain_id: u32) -> Result<ethers::signers::Wallet<SigningKey>> {
+    async fn build_signer(
+        &self,
+        chain_id: u32,
+        _path: &str,
+    ) -> Result<ethers::signers::Wallet<SigningKey>> {
+        // TODO: ensure path exists
+
         Ok(MnemonicBuilder::<English>::default()
             .phrase(self.mnemonic.as_ref())
             .derivation_path(&self.current_path)?

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -13,9 +13,22 @@ pub trait WalletControl: Sync + Send + Deserialize<'static> + Serialize + std::f
     fn name(&self) -> String;
     async fn update(mut self, params: Json) -> Result<Wallet>;
     async fn get_current_address(&self) -> ChecksummedAddress;
+    fn get_current_path(&self) -> String;
     async fn set_current_path(&mut self, path: String) -> Result<()>;
     async fn get_all_addresses(&self) -> Vec<(String, ChecksummedAddress)>;
-    async fn build_signer(&self, chain_id: u32) -> Result<ethers::signers::Wallet<SigningKey>>;
+
+    async fn build_signer(
+        &self,
+        chain_id: u32,
+        path: &str,
+    ) -> Result<ethers::signers::Wallet<SigningKey>>;
+
+    async fn build_current_signer(
+        &self,
+        chain_id: u32,
+    ) -> Result<ethers::signers::Wallet<SigningKey>> {
+        self.build_signer(chain_id, &self.get_current_path()).await
+    }
 
     fn is_dev(&self) -> bool {
         false


### PR DESCRIPTION
This refactor has three interesting benefits:

* It now applies a Builder pattern, which allows us to no longer have `Option<T>` in the logic itself. less unwraps and error handling to go around
* It defers the signer building process until the very end, meaning we only ask for a password after the transaction has been approved. The UX of asking for a password only to later reject a transaction would not be ideal
* We can now simulate the transaction & estimate gas without having a signer at all. This will be important in impersonation wallets, where signers can't even be built