### PR TITLE
fix: go submenu adding unexistent item

### DIFF
--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -122,7 +122,6 @@ impl IronApp {
         let go_submenu = Submenu::new(
             "Go",
             Menu::new()
-                .add_item(details)
                 .add_item(transactions)
                 .add_item(balances)
                 .add_item(contracts)


### PR DESCRIPTION
**Why:**
![Screenshot 2023-07-23 at 00 14 05](https://github.com/iron-wallet/iron/assets/6967377/da203b0d-5f90-4f44-aab2-2758b9f6809e)

**How:**
Following up on the changes in https://github.com/iron-wallet/iron/commit/3541f1f9362abc05182c52df14e6fed069780bcc this PR removes the `details` item which was being added to the _go sub menu_ but not instantiated. 