### PR TITLE
Using iron_broadcast instead of propagating a sender object everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,6 +2750,7 @@ name = "iron"
 version = "0.4.1"
 dependencies = [
  "fix-path-env",
+ "iron-broadcast",
  "iron-db",
  "iron-dialogs",
  "iron-forge",
@@ -2819,6 +2820,7 @@ dependencies = [
 name = "iron-dialogs"
 version = "0.4.1"
 dependencies = [
+ "iron-broadcast",
  "iron-types",
  "once_cell",
  "serde",

--- a/bin/iron/Cargo.toml
+++ b/bin/iron/Cargo.toml
@@ -20,6 +20,7 @@ iron-types = { workspace = true }
 iron-db = { workspace = true }
 iron-sync = { workspace = true }
 iron-tracing = { workspace = true }
+iron-broadcast = { workspace = true }
 tauri = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }

--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
+use iron_broadcast::UIMsg;
 use iron_db::DB;
-use iron_types::ui_events::UIReceiver;
-use iron_types::{ui_events, UIEvent, UISender};
+use iron_types::ui_events;
 use tauri::{
     AppHandle, Builder, CustomMenuItem, GlobalWindowEvent, Manager, SystemTray, SystemTrayEvent,
     SystemTrayMenu, SystemTrayMenuItem, WindowBuilder, WindowEvent, WindowUrl,
@@ -10,7 +10,6 @@ use tauri::{
 #[cfg(not(target_os = "linux"))]
 use tauri::{Menu, Submenu, WindowMenuEvent};
 use tauri_plugin_window_state::{AppHandleExt, Builder as windowStatePlugin, StateFlags};
-use tokio::sync::mpsc;
 
 use crate::error::AppResult;
 
@@ -20,8 +19,6 @@ pub struct IronApp {
 
 impl IronApp {
     pub async fn build() -> AppResult<Self> {
-        let (snd, rcv) = mpsc::unbounded_channel();
-
         let tray = Self::build_tray();
 
         let mut builder = Builder::default()
@@ -62,7 +59,7 @@ impl IronApp {
                 let handle = app.handle();
 
                 tauri::async_runtime::spawn(async move {
-                    event_listener(handle, rcv).await;
+                    event_listener(handle).await;
                 });
 
                 #[cfg(feature = "debug")]
@@ -93,7 +90,7 @@ impl IronApp {
             .expect("error while running tauri application");
 
         let db = DB::connect(&resource(&app, "db.sqlite3")).await?;
-        init(&app, &db, snd).await?;
+        init(&app, &db).await?;
 
         app.manage(db);
         let res = Self { app };
@@ -156,16 +153,15 @@ fn on_menu_event(event: WindowMenuEvent) {
     }
 }
 
-async fn init(app: &tauri::App, db: &DB, snd: UISender) -> AppResult<()> {
+async fn init(app: &tauri::App, db: &DB) -> AppResult<()> {
     // anvil needs to be started before networks, otherwise the initial tracker won't be ready to
     // spawn
-    iron_sync::init(db.clone(), snd.clone()).await;
+    iron_sync::init(db.clone()).await;
 
-    iron_dialogs::init(snd.clone());
     iron_settings::init(resource(app, "settings.json")).await;
-    iron_ws::init(snd.clone());
-    iron_wallets::init(resource(app, "wallets.json"), snd.clone()).await;
-    iron_networks::init(resource(app, "networks.json"), snd.clone()).await;
+    iron_ws::init();
+    iron_wallets::init(resource(app, "wallets.json")).await;
+    iron_networks::init(resource(app, "networks.json")).await;
     iron_forge::init().await?;
 
     Ok(())
@@ -215,50 +211,54 @@ fn show_main_window(app: &AppHandle) {
     }
 }
 
-async fn event_listener(handle: AppHandle, mut rcv: UIReceiver) {
-    while let Some(msg) = rcv.recv().await {
-        use UIEvent::*;
+async fn event_listener(handle: AppHandle) {
+    let mut rx = iron_broadcast::subscribe_ui().await;
 
-        match msg {
-            Notify(msg) => {
-                // forward directly to main window
-                // if window is not open, just ignore them
-                if let Some(window) = handle.get_window("main") {
-                    window.emit(msg.label(), &msg).unwrap();
+    loop {
+        if let Ok(msg) = rx.recv().await {
+            use UIMsg::*;
+
+            match msg {
+                Notify(msg) => {
+                    // forward directly to main window
+                    // if window is not open, just ignore them
+                    if let Some(window) = handle.get_window("main") {
+                        window.emit(msg.label(), &msg).unwrap();
+                    }
                 }
-            }
 
-            DialogOpen(ui_events::DialogOpen {
-                label,
-                title,
-                url,
-                w,
-                h,
-            }) => {
-                WindowBuilder::new(&handle, label, WindowUrl::App(url.into()))
-                    .min_inner_size(w, h)
-                    .max_inner_size(w, h)
-                    .title(title)
-                    .build()
-                    .unwrap();
-            }
-
-            DialogClose(ui_events::DialogClose { label }) => {
-                if let Some(window) = handle.get_window(&label) {
-                    window.close().unwrap();
+                DialogOpen(ui_events::DialogOpen {
+                    label,
+                    title,
+                    url,
+                    w,
+                    h,
+                }) => {
+                    WindowBuilder::new(&handle, label, WindowUrl::App(url.into()))
+                        .min_inner_size(w, h)
+                        .max_inner_size(w, h)
+                        .title(title)
+                        .build()
+                        .unwrap();
                 }
-            }
 
-            DialogSend(ui_events::DialogSend {
-                label,
-                event_type,
-                payload,
-            }) => {
-                handle
-                    .get_window(&label)
-                    .unwrap()
-                    .emit(&event_type, &payload)
-                    .unwrap();
+                DialogClose(ui_events::DialogClose { label }) => {
+                    if let Some(window) = handle.get_window(&label) {
+                        window.close().unwrap();
+                    }
+                }
+
+                DialogSend(ui_events::DialogSend {
+                    label,
+                    event_type,
+                    payload,
+                }) => {
+                    handle
+                        .get_window(&label)
+                        .unwrap()
+                        .emit(&event_type, &payload)
+                        .unwrap();
+                }
             }
         }
     }

--- a/bin/iron/src/error.rs
+++ b/bin/iron/src/error.rs
@@ -1,5 +1,3 @@
-use iron_types::UIEvent;
-
 #[derive(thiserror::Error, Debug)]
 pub enum AppError {
     #[error(transparent)]
@@ -10,9 +8,6 @@ pub enum AppError {
 
     #[error(transparent)]
     FixPathEnv(#[from] fix_path_env::Error),
-
-    #[error(transparent)]
-    WindowSend(#[from] tokio::sync::mpsc::error::SendError<UIEvent>),
 
     #[error(transparent)]
     TauriError(#[from] tauri::Error),

--- a/crates/dialogs/Cargo.toml
+++ b/crates/dialogs/Cargo.toml
@@ -10,6 +10,7 @@ authors.workspace = true
 
 [dependencies]
 iron-types = { workspace = true }
+iron-broadcast = { workspace = true }
 
 tauri = { workspace = true }
 serde = { workspace = true }

--- a/crates/dialogs/src/error.rs
+++ b/crates/dialogs/src/error.rs
@@ -8,9 +8,6 @@ pub enum Error {
 
     #[error(transparent)]
     Send(#[from] mpsc::error::SendError<super::handle::DialogMsg>),
-
-    #[error(transparent)]
-    WindowSend(#[from] mpsc::error::SendError<iron_types::UIEvent>),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/dialogs/src/global.rs
+++ b/crates/dialogs/src/global.rs
@@ -1,18 +1,9 @@
 use std::collections::HashMap;
 
-use iron_types::UISender;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
 
 type PendingDialogMap = HashMap<u32, super::handle::Dialog>;
 
-/// a sender used internally to go through the app's event loop, which is required for
-/// opening dialogs
-pub static APP_SND: OnceCell<UISender> = OnceCell::new();
-
 /// global map of pending dialogs
 pub(super) static OPEN_DIALOGS: Lazy<Mutex<PendingDialogMap>> = Lazy::new(Default::default);
-
-pub fn init(window_snd: UISender) {
-    APP_SND.set(window_snd).unwrap();
-}

--- a/crates/dialogs/src/handle.rs
+++ b/crates/dialogs/src/handle.rs
@@ -3,7 +3,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use iron_types::ui_events::{DialogClose, DialogOpen, DialogSend};
-use iron_types::{Json, UIEvent, UISender};
+use iron_types::Json;
 use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
 
 use super::{global::OPEN_DIALOGS, presets, Result};
@@ -36,12 +36,12 @@ impl Dialog {
         let clone = self.clone();
         let inner = self.read().await;
         OPEN_DIALOGS.lock().await.insert(inner.id, clone);
-        inner.open()
+        inner.open().await
     }
 
     /// Closes the dialog window
     pub async fn close(self) -> Result<()> {
-        self.read().await.close()
+        self.read().await.close().await
     }
 
     /// Gets a copy of the payload intended for the dialog
@@ -57,7 +57,7 @@ impl Dialog {
 
     /// Sends an event to the dialog
     pub async fn send(&self, event_type: &str, payload: Option<Json>) -> Result<()> {
-        self.read().await.send(event_type, payload)
+        self.read().await.send(event_type, payload).await
     }
 
     /// Awaits data received from the dialog
@@ -87,9 +87,6 @@ pub struct Inner {
     /// payload to first send to dialog
     payload: Json,
 
-    /// app channel
-    app_snd: UISender,
-
     /// inbound msgs from dialog
     inbound_snd: mpsc::UnboundedSender<DialogMsg>,
 
@@ -112,40 +109,45 @@ impl Inner {
             id,
             preset: preset.to_string(),
             payload,
-            app_snd: crate::global::APP_SND.get().unwrap().clone(),
             inbound_snd: snd,
             inbound_rcv: RwLock::new(rcv),
         }
     }
 
-    fn open(&self) -> Result<()> {
+    async fn open(&self) -> Result<()> {
         let preset = presets::PRESETS.get(&self.preset).unwrap();
         let url = format!("/dialog/{}/{}", self.preset, self.id);
         let title = format!("Iron Dialog - {}", preset.title);
 
-        Ok(self.app_snd.send(UIEvent::DialogOpen(DialogOpen {
+        iron_broadcast::dialog_open(DialogOpen {
             label: self.label(),
             title,
             url,
             w: preset.w,
             h: preset.h,
-        }))?)
-    }
-
-    fn close(&self) -> Result<()> {
-        self.app_snd.send(UIEvent::DialogClose(DialogClose {
-            label: self.label(),
-        }))?;
+        })
+        .await;
 
         Ok(())
     }
 
-    fn send(&self, event_type: &str, payload: Option<Json>) -> Result<()> {
-        self.app_snd.send(UIEvent::DialogSend(DialogSend {
+    async fn close(&self) -> Result<()> {
+        iron_broadcast::dialog_close(DialogClose {
+            label: self.label(),
+        })
+        .await;
+
+        Ok(())
+    }
+
+    async fn send(&self, event_type: &str, payload: Option<Json>) -> Result<()> {
+        iron_broadcast::dialog_send(DialogSend {
             label: self.label(),
             event_type: event_type.into(),
             payload,
-        }))?;
+        })
+        .await;
+
         Ok(())
     }
 

--- a/crates/dialogs/src/lib.rs
+++ b/crates/dialogs/src/lib.rs
@@ -5,5 +5,4 @@ mod handle;
 mod presets;
 
 pub use error::{Error, Result};
-pub use global::init;
 pub use handle::{Dialog, DialogMsg};

--- a/crates/networks/src/error.rs
+++ b/crates/networks/src/error.rs
@@ -1,5 +1,3 @@
-use iron_types::UIEvent;
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("IO error: {0}")]
@@ -7,9 +5,6 @@ pub enum Error {
 
     #[error("serialization error: {0}")]
     Serde(#[from] serde_json::Error),
-
-    #[error("error sending event to window: {0}")]
-    WindowSend(#[from] tokio::sync::mpsc::error::SendError<UIEvent>),
 
     #[error(transparent)]
     Url(#[from] url::ParseError),

--- a/crates/networks/src/init.rs
+++ b/crates/networks/src/init.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use iron_types::{GlobalState, UISender};
+use iron_types::GlobalState;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -15,7 +15,7 @@ use super::{network::Network, Networks};
 
 static NETWORKS: OnceCell<RwLock<Networks>> = OnceCell::new();
 
-pub async fn init(pathbuf: PathBuf, window_snd: UISender) {
+pub async fn init(pathbuf: PathBuf) {
     /// The persisted format of the networks object
     #[derive(Debug, Deserialize)]
     struct PersistedNetworks {
@@ -35,7 +35,6 @@ pub async fn init(pathbuf: PathBuf, window_snd: UISender) {
             networks: res.networks,
             current: res.current,
             file: pathbuf,
-            window_snd,
         }
     } else {
         let networks = Network::all_default();
@@ -44,7 +43,6 @@ pub async fn init(pathbuf: PathBuf, window_snd: UISender) {
             networks: networks.into_iter().map(|n| (n.name.clone(), n)).collect(),
             current,
             file: pathbuf,
-            window_snd,
         }
     };
 

--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 
 use ethers::providers::{Http, Provider};
 pub use init::init;
-use iron_types::{UINotify, UISender};
+use iron_types::UINotify;
 use serde::Serialize;
 
 pub use self::error::{Error, Result};
@@ -25,9 +25,6 @@ pub struct Networks {
 
     #[serde(skip)]
     file: PathBuf,
-
-    #[serde(skip)]
-    window_snd: UISender,
 }
 
 impl Networks {
@@ -90,7 +87,7 @@ impl Networks {
 
     async fn on_network_changed(&self) -> Result<()> {
         self.notify_peers();
-        self.window_snd.send(UINotify::NetworkChanged.into())?;
+        iron_broadcast::ui_notify(UINotify::NetworkChanged).await;
 
         let chain_id = self.get_current_network().chain_id;
         iron_broadcast::current_network_changed(chain_id).await;

--- a/crates/sync/alchemy/src/error.rs
+++ b/crates/sync/alchemy/src/error.rs
@@ -1,5 +1,4 @@
 use ethers::{providers::JsonRpcError, types::H256};
-use iron_types::UIEvent;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -11,9 +10,6 @@ pub enum Error {
 
     #[error("serialization error: {0}")]
     Serde(#[from] serde_json::Error),
-
-    #[error("error sending event to window: {0}")]
-    WindowSend(#[from] tokio::sync::mpsc::error::SendError<UIEvent>),
 
     #[error(transparent)]
     Url(#[from] url::ParseError),

--- a/crates/sync/anvil/src/error.rs
+++ b/crates/sync/anvil/src/error.rs
@@ -1,5 +1,4 @@
 use ethers::types::H256;
-use iron_types::UIEvent;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -8,9 +7,6 @@ pub enum Error {
 
     #[error(transparent)]
     DB(#[from] iron_db::Error),
-
-    #[error(transparent)]
-    WindowSend(#[from] tokio::sync::mpsc::error::SendError<UIEvent>),
 
     #[error(transparent)]
     EthersProvider(#[from] ethers::providers::ProviderError),

--- a/crates/sync/anvil/src/global.rs
+++ b/crates/sync/anvil/src/global.rs
@@ -2,25 +2,22 @@ use std::collections::HashMap;
 
 use iron_broadcast::InternalMsg;
 use iron_db::DB;
-use iron_types::UIEvent;
 use once_cell::sync::{Lazy, OnceCell};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::Mutex;
 use url::Url;
 
 use crate::tracker::Tracker;
 
 static DB: OnceCell<DB> = OnceCell::new();
-static WINDOW_SND: OnceCell<mpsc::UnboundedSender<UIEvent>> = OnceCell::new();
 static LISTENERS: Lazy<Mutex<HashMap<u32, Tracker>>> = Lazy::new(Default::default);
 
-pub fn init(db: DB, window_snd: mpsc::UnboundedSender<UIEvent>) {
+pub fn init(db: DB) {
     DB.set(db).unwrap();
-    WINDOW_SND.set(window_snd).unwrap();
     tokio::spawn(async { receiver().await });
 }
 
 async fn receiver() -> ! {
-    let mut rx = iron_broadcast::subscribe().await;
+    let mut rx = iron_broadcast::subscribe_internal().await;
 
     loop {
         if let Ok(InternalMsg::ResetAnvilListener { chain_id, http, ws }) = rx.recv().await {
@@ -32,13 +29,7 @@ async fn receiver() -> ! {
 async fn reset_listener(chain_id: u32, http: Url, ws: Url) {
     LISTENERS.lock().await.remove(&chain_id);
 
-    let listener = Tracker::run(
-        chain_id,
-        http,
-        ws,
-        DB.get().unwrap().clone(),
-        WINDOW_SND.get().unwrap().clone(),
-    );
+    let listener = Tracker::run(chain_id, http, ws, DB.get().unwrap().clone());
 
     LISTENERS.lock().await.insert(chain_id, listener);
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -9,7 +9,7 @@ use ethers::types::{Address, U256};
 pub use events::Event;
 pub use global_state::GlobalState;
 pub use tokens::{TokenBalance, TokenMetadata};
-pub use ui_events::{UIEvent, UINotify, UISender};
+pub use ui_events::UINotify;
 
 pub type Json = serde_json::Value;
 

--- a/crates/types/src/ui_events.rs
+++ b/crates/types/src/ui_events.rs
@@ -1,23 +1,5 @@
 use serde::Serialize;
 
-pub type UISender = tokio::sync::mpsc::UnboundedSender<UIEvent>;
-pub type UIReceiver = tokio::sync::mpsc::UnboundedReceiver<UIEvent>;
-
-#[derive(Debug, Clone)]
-pub enum UIEvent {
-    /// notify the frontend about a state change
-    Notify(UINotify),
-
-    /// open a dialog
-    DialogOpen(DialogOpen),
-
-    /// close a dialog
-    DialogClose(DialogClose),
-
-    /// sends a new event to a dialog
-    DialogSend(DialogSend),
-}
-
 #[derive(Debug, Clone)]
 pub struct DialogOpen {
     pub label: String,
@@ -59,11 +41,5 @@ impl UINotify {
             Self::PeersUpdated => "peers-updated",
             Self::BalancesUpdated => "balances-updated",
         }
-    }
-}
-
-impl From<UINotify> for UIEvent {
-    fn from(value: UINotify) -> Self {
-        UIEvent::Notify(value)
     }
 }

--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -1,4 +1,3 @@
-use iron_types::UIEvent;
 use serde::Serialize;
 use tokio::sync::oneshot;
 
@@ -33,9 +32,6 @@ pub enum Error {
 
     #[error("unknown wallet key: {0}")]
     InvalidKey(String),
-
-    #[error("error sending event to window: {0}")]
-    WindowSend(#[from] tokio::sync::mpsc::error::SendError<UIEvent>),
 
     #[error("invalid wallet type: {0}")]
     InvalidWalletType(String),

--- a/crates/wallets/src/hd_wallet.rs
+++ b/crates/wallets/src/hd_wallet.rs
@@ -71,7 +71,7 @@ impl WalletControl for HDWallet {
     }
 
     async fn get_current_address(&self) -> ChecksummedAddress {
-        self.current.1.clone()
+        self.current.1
     }
 
     fn get_current_path(&self) -> String {

--- a/crates/wallets/src/init.rs
+++ b/crates/wallets/src/init.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use iron_types::{GlobalState, UISender};
+use iron_types::GlobalState;
 use once_cell::sync::OnceCell;
 use serde::Deserialize;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -14,7 +14,7 @@ use super::{Wallet, Wallets};
 
 static WALLETS: OnceCell<RwLock<Wallets>> = OnceCell::new();
 
-pub async fn init(pathbuf: PathBuf, window_snd: UISender) {
+pub async fn init(pathbuf: PathBuf) {
     let path = Path::new(&pathbuf);
 
     #[derive(Debug, Deserialize)]
@@ -34,14 +34,12 @@ pub async fn init(pathbuf: PathBuf, window_snd: UISender) {
             wallets: res.wallets,
             current: res.current,
             file: Some(pathbuf),
-            window_snd,
         }
     } else {
         Wallets {
             wallets: Default::default(),
             current: 0,
             file: Some(pathbuf),
-            window_snd,
         }
     };
 

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -105,10 +105,10 @@ impl Wallets {
             let before: HashSet<_> = before.into_iter().collect();
             let after: HashSet<_> = after.into_iter().collect();
             for (_, a) in after.difference(&before) {
-                iron_broadcast::address_added(a.clone()).await;
+                iron_broadcast::address_added(*a).await;
             }
             for (_, a) in before.difference(&after) {
-                iron_broadcast::address_removed(a.clone()).await;
+                iron_broadcast::address_removed(*a).await;
             }
         });
 

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
 
 pub use error::{Error, Result};
 pub use init::init;
-use iron_types::{ChecksummedAddress, Json, UINotify, UISender};
+use iron_types::{ChecksummedAddress, Json, UINotify};
 use serde::Serialize;
 
 use self::wallet::WalletCreate;
@@ -33,9 +33,6 @@ pub struct Wallets {
 
     #[serde(default)]
     current: usize,
-
-    #[serde(skip)]
-    window_snd: UISender,
 
     #[serde(skip)]
     file: Option<PathBuf>,
@@ -194,7 +191,7 @@ impl Wallets {
         let addr = self.get_current_address().await;
 
         self.notify_peers().await;
-        self.window_snd.send(UINotify::WalletsChanged.into())?;
+        iron_broadcast::ui_notify(UINotify::WalletsChanged).await;
         iron_broadcast::current_address_changed(addr).await;
 
         Ok(())

--- a/crates/ws/src/error.rs
+++ b/crates/ws/src/error.rs
@@ -1,5 +1,3 @@
-use iron_types::UIEvent;
-
 #[derive(thiserror::Error, Debug)]
 pub enum WsError {
     #[error(transparent)]
@@ -7,9 +5,6 @@ pub enum WsError {
 
     #[error(transparent)]
     IO(#[from] std::io::Error),
-
-    #[error(transparent)]
-    WindowSend(#[from] tokio::sync::mpsc::error::SendError<UIEvent>),
 
     #[error(transparent)]
     TauriError(#[from] tauri::Error),

--- a/crates/ws/src/peers.rs
+++ b/crates/ws/src/peers.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, net::SocketAddr};
 
-use iron_types::{ChecksummedAddress, UINotify, UISender};
+use iron_types::{ChecksummedAddress, UINotify};
 use serde::Serialize;
 use serde_json::json;
 use tokio::sync::mpsc;
@@ -46,30 +46,24 @@ impl Peer {
 }
 
 /// Tracks a list of peers, usually browser tabs, that connect to the app
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Peers {
     map: HashMap<SocketAddr, Peer>,
-    window_snd: UISender,
 }
 
 impl Peers {
-    pub fn new(window_snd: UISender) -> Self {
-        Self {
-            map: HashMap::new(),
-            window_snd,
-        }
-    }
-
     /// Adds a new peer
-    pub fn add_peer(&mut self, peer: Peer) {
+    pub async fn add_peer(&mut self, peer: Peer) {
         self.map.insert(peer.socket, peer);
-        self.window_snd.send(UINotify::PeersUpdated.into()).unwrap();
+        iron_broadcast::ui_notify(UINotify::PeersUpdated).await;
+        //self.window_snd.send(UINotify::PeersUpdated.into()).unwrap();
     }
 
     /// Removes an existing peer
-    pub fn remove_peer(&mut self, peer: SocketAddr) {
+    pub async fn remove_peer(&mut self, peer: SocketAddr) {
         self.map.remove(&peer);
-        self.window_snd.send(UINotify::PeersUpdated.into()).unwrap();
+        iron_broadcast::ui_notify(UINotify::PeersUpdated).await;
+        //self.window_snd.send(UINotify::PeersUpdated.into()).unwrap();
     }
 
     /// Broadcasts an `accountsChanged` event to all peers

--- a/crates/ws/src/server.rs
+++ b/crates/ws/src/server.rs
@@ -48,9 +48,9 @@ async fn accept_connection(socket: SocketAddr, stream: TcpStream) {
 
     let peer = Peer::new(socket, snd, &query_params);
 
-    Peers::write().await.add_peer(peer);
+    Peers::write().await.add_peer(peer).await;
     let err = handle_connection(ws_stream, rcv).await;
-    Peers::write().await.remove_peer(socket);
+    Peers::write().await.remove_peer(socket).await;
 
     if let Err(e) = err {
         match e {

--- a/gui/src/components/Txs.tsx
+++ b/gui/src/components/Txs.tsx
@@ -26,8 +26,6 @@ export function Txs() {
 
   const [pages, setPages] = useState<Paginated<Tx>[]>([]);
 
-  console.log("rendering");
-  console.log(pages.length);
   const loadMore = () => {
     let pagination: Pagination = {};
     const last = pages?.at(-1)?.pagination;


### PR DESCRIPTION
This was a low-hanging fruit. After initially introducing `iron_broadcast`, we now have a safe global way to send messages across different components. but the UI messages were still being handled by sending a `window_snd` object everywhere

This creates a new sender module for UI msgs in `iron_broadcast`, and replaces all previous `window_snd` ocurrences with it

I'm targeting this PR to the `better-fetch` branch, corresponding to #316 , because this refactor was largely motivated and dependant on what happened there