### PR TITLE
Add Sidebar

### DIFF
--- a/bin/iron/tauri.conf.json
+++ b/bin/iron/tauri.conf.json
@@ -47,7 +47,7 @@
       {
         "fullscreen": false,
         "resizable": true,
-        "title": "iron",
+        "title": "",
         "width": 1200,
         "height": 800,
         "titleBarStyle": "Overlay"

--- a/bin/iron/tauri.conf.json
+++ b/bin/iron/tauri.conf.json
@@ -49,7 +49,8 @@
         "resizable": true,
         "title": "iron",
         "width": 1200,
-        "height": 800
+        "height": 800,
+        "titleBarStyle": "Overlay"
       }
     ]
   }

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -49,11 +49,11 @@ function Routes() {
         <Route path="/dialog/wallet-unlock/:id">
           {({ id }: { id: string }) => <WalletUnlockDialog id={parseInt(id)} />}
         </Route>
-
         <Route>
-          <Navbar />
-          <HomePage />
-          <CommandBar />
+          <CommandBar>
+            <Navbar />
+            <HomePage />
+          </CommandBar>
         </Route>
       </Switch>
     </Router>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -7,7 +7,6 @@ import {
   CommandBar,
   HomePage,
   MsgSignDialog,
-  Navbar,
   TxReviewDialog,
   WagmiWrapper,
   WalletUnlockDialog,
@@ -51,7 +50,6 @@ function Routes() {
         </Route>
         <Route>
           <CommandBar>
-            <Navbar />
             <HomePage />
           </CommandBar>
         </Route>

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -1,20 +1,61 @@
-import { Box, Divider, Stack } from "@mui/material";
-
-import { useWallets } from "../store";
-import { AddressView, BalancesList } from "./";
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  IconButton,
+  Typography,
+} from "@mui/material";
+import { useTheme, useWallets } from "../store";
+import { AddressView, BalancesList, Panel } from "./";
+import { ContentCopySharp } from "@mui/icons-material";
 
 export function Balances() {
+  const { theme } = useTheme();
   const address = useWallets((s) => s.address);
 
   if (!address) return null;
 
   return (
-    <Stack direction="column" justifyContent="center" spacing={1}>
-      <Box alignSelf="center">
-        <AddressView address={address} />
+    <Panel>
+      <Typography fontSize={32} mb={2}>
+        Balances
+      </Typography>
+
+      <Box
+        display="flex"
+        flexDirection="row-reverse"
+        alignItems="flex-start"
+        justifyContent="flex-end"
+        rowGap={1}
+        columnGap={2}
+        sx={{
+          [theme.breakpoints.down("sm")]: {
+            flexDirection: "column",
+          },
+        }}
+      >
+        <Card sx={{ width: "fit-content" }}>
+          <CardContent sx={{ pb: 0 }}>
+            <Typography
+              textTransform="uppercase"
+              fontSize={12}
+              color="text.secondary"
+            >
+              Account
+            </Typography>
+            <Typography>
+              <AddressView address={address} />
+            </Typography>
+          </CardContent>
+          <CardActions disableSpacing>
+            <IconButton>
+              <ContentCopySharp fontSize="small" />
+            </IconButton>
+          </CardActions>
+        </Card>
+        <BalancesList />
       </Box>
-      <Divider />
-      <BalancesList />
-    </Stack>
+    </Panel>
   );
 }

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -1,3 +1,4 @@
+import { ContentCopySharp } from "@mui/icons-material";
 import {
   Box,
   Card,
@@ -6,9 +7,9 @@ import {
   IconButton,
   Typography,
 } from "@mui/material";
+
 import { useTheme, useWallets } from "../store";
 import { AddressView, BalancesList, Panel } from "./";
-import { ContentCopySharp } from "@mui/icons-material";
 
 export function Balances() {
   const { theme } = useTheme();

--- a/gui/src/components/Balances.tsx
+++ b/gui/src/components/Balances.tsx
@@ -18,10 +18,6 @@ export function Balances() {
 
   return (
     <Panel>
-      <Typography fontSize={32} mb={2}>
-        Balances
-      </Typography>
-
       <Box
         display="flex"
         flexDirection="row-reverse"

--- a/gui/src/components/BalancesList.tsx
+++ b/gui/src/components/BalancesList.tsx
@@ -4,7 +4,6 @@ import {
   ListItem,
   ListItemAvatar,
   ListItemText,
-  Stack,
 } from "@mui/material";
 import truncateEthAddress from "truncate-eth-address";
 import { Address, formatUnits } from "viem";
@@ -12,18 +11,14 @@ import { Address, formatUnits } from "viem";
 import { useInvoke } from "../hooks";
 import { useBalances, useNetworks } from "../store";
 import { GeneralSettings } from "../types";
-import { CopyToClipboard, IconCrypto, Panel } from "./";
+import { CopyToClipboard, IconCrypto } from "./";
 
 export function BalancesList() {
   return (
-    <Panel>
-      <Stack>
-        <List>
-          <BalanceETH />
-          <BalancesERC20 />
-        </List>
-      </Stack>
-    </Panel>
+    <List>
+      <BalanceETH />
+      <BalancesERC20 />
+    </List>
   );
 }
 

--- a/gui/src/components/CommandBar.tsx
+++ b/gui/src/components/CommandBar.tsx
@@ -21,19 +21,22 @@ import {
   useMatches,
   useRegisterActions,
 } from "kbar";
-import React, { forwardRef } from "react";
+import React, { ReactNode, forwardRef } from "react";
 
 import { useNetworks, useWallets } from "../store";
 import { useTheme } from "../store/theme";
 
-export function CommandBar() {
+export function CommandBar({ children }: { children: ReactNode }) {
+  const { theme } = useTheme();
+
   return (
     <KBarProvider>
       <KBarPortal>
-        <KBarPositioner>
+        <KBarPositioner style={{ zIndex: theme.zIndex.tooltip + 1 }}>
           <CommandBarInner />
         </KBarPositioner>
       </KBarPortal>
+      {children}
     </KBarProvider>
   );
 }

--- a/gui/src/components/CommandBarButton.tsx
+++ b/gui/src/components/CommandBarButton.tsx
@@ -1,18 +1,19 @@
-import Settings from "@mui/icons-material/SettingsSharp";
+import TerminalSharpIcon from "@mui/icons-material/TerminalSharp";
 import { Button, IconButton } from "@mui/material";
-import { useState } from "react";
+import { useKBar } from "kbar";
 
-import { Modal, Settings as SettingsPage } from "./";
 import { useTheme } from "../store";
 
-export function SettingsButton() {
-  const [showSettings, setShowSettings] = useState(false);
+export function CommandBarButton() {
+  const kbar = useKBar();
   const { theme } = useTheme();
+
+  const handleClick = () => kbar.query.toggle();
 
   return (
     <>
       <IconButton
-        onClick={() => setShowSettings(true)}
+        onClick={handleClick}
         color="inherit"
         sx={{
           height: 40,
@@ -23,14 +24,14 @@ export function SettingsButton() {
           },
         }}
       >
-        <Settings />
+        <TerminalSharpIcon />
       </IconButton>
 
       <Button
         color="inherit"
         fullWidth
-        startIcon={<Settings />}
-        onClick={() => setShowSettings(true)}
+        startIcon={<TerminalSharpIcon />}
+        onClick={handleClick}
         sx={{
           justifyContent: "flex-start",
           [theme.breakpoints.down("md")]: {
@@ -38,19 +39,8 @@ export function SettingsButton() {
           },
         }}
       >
-        Settings
+        Command Bar
       </Button>
-
-      <Modal
-        open={showSettings}
-        onClose={() => setShowSettings(false)}
-        sx={{
-          width: "80%",
-          height: "80%",
-        }}
-      >
-        <SettingsPage />
-      </Modal>
     </>
   );
 }

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -1,40 +1,34 @@
-import { Box, Container } from "@mui/material";
+import { Box } from "@mui/material";
 import { Route, Switch } from "wouter";
 
-import {
-  Balances,
-  LivenetPlaceholder,
-  NestedRoutes,
-  NewVersionNotice,
-} from "./";
+import { LivenetPlaceholder, Navbar, NestedRoutes, NewVersionNotice } from "./";
 import { Sidebar, TABS } from "./Sidebar";
+
+const defaultTab = TABS[0];
 
 export function HomePage() {
   return (
     <Box>
       <Sidebar>
-        <Container
-          // sx={{ pl: `${DRAWER_WIDTH_MD}px` }}
-          sx={{ m: 0 }}
-          disableGutters
-          maxWidth="md"
-        >
-          <NestedRoutes base="/">
-            <Switch>
-              {TABS.map((tab) => (
-                <Route key={tab.path} path={tab.path}>
+        <NestedRoutes base="/">
+          <Switch>
+            {TABS.map((tab) => (
+              <Route key={tab.path} path={tab.path}>
+                <>
+                  <Navbar tab={tab} />
                   <LivenetPlaceholder devOnly={tab.devOnly}>
                     <tab.component />
                   </LivenetPlaceholder>
-                </Route>
-              ))}
-              <Route>
-                <Balances />
+                </>
               </Route>
-            </Switch>
-          </NestedRoutes>
-          <NewVersionNotice />
-        </Container>
+            ))}
+            <Route>
+              <Navbar tab={defaultTab} />
+              <defaultTab.component />
+            </Route>
+          </Switch>
+        </NestedRoutes>
+        <NewVersionNotice />
       </Sidebar>
     </Box>
   );

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -1,81 +1,40 @@
-import { Container, Tab, Tabs } from "@mui/material";
-import { findIndex, parseInt, range, toString } from "lodash-es";
-import { Link, Route, Switch, useLocation, useRoute } from "wouter";
+import { Box, Container } from "@mui/material";
+import { Route, Switch } from "wouter";
 
-import { useKeyPress, useMenuAction } from "../hooks";
 import {
   Balances,
-  Contracts,
   LivenetPlaceholder,
   NestedRoutes,
   NewVersionNotice,
-  Peers,
-  Txs,
 } from "./";
-
-const tabs = [
-  { path: "details", name: "Balances", component: Balances },
-  { path: "transactions", name: "Transactions", component: Txs },
-  { path: "contracts", name: "Contracts", component: Contracts, devOnly: true },
-  { path: "connections", name: "Connections", component: Peers },
-];
+import { Sidebar, TABS } from "./Sidebar";
 
 export function HomePage() {
-  const [_match, params] = useRoute("/:path");
-  const [_location, setLocation] = useLocation();
-
-  useMenuAction((payload) => setLocation(payload));
-
-  const handleKeyboardNavigation = (event: KeyboardEvent) => {
-    setLocation(tabs[parseInt(event.key) - 1].path);
-  };
-
-  useKeyPress(
-    range(1, tabs.length + 1).map(toString),
-    { meta: true },
-    handleKeyboardNavigation
-  );
-
-  useKeyPress(
-    range(1, tabs.length + 1).map(toString),
-    { ctrl: true },
-    handleKeyboardNavigation
-  );
-
   return (
-    <Container disableGutters maxWidth="md">
-      <Tabs
-        variant="fullWidth"
-        sx={{ mb: 2 }}
-        value={Math.max(findIndex(tabs, { path: params?.path }), 0)}
-      >
-        {tabs.map((tab) => (
-          <Tab
-            LinkComponent={Link}
-            href={tab.path}
-            key={tab.name}
-            label={tab.name}
-          />
-        ))}
-      </Tabs>
-
-      <div role="tabpanel">
-        <NestedRoutes base="/">
-          <Switch>
-            {tabs.map((tab) => (
-              <Route key={tab.path || "/"} path={tab.path}>
-                <LivenetPlaceholder devOnly={tab.devOnly}>
-                  <tab.component />
-                </LivenetPlaceholder>
+    <Box>
+      <Sidebar>
+        <Container
+          // sx={{ pl: `${DRAWER_WIDTH_MD}px` }}
+          disableGutters
+          maxWidth="md"
+        >
+          <NestedRoutes base="/">
+            <Switch>
+              {TABS.map((tab) => (
+                <Route key={tab.path || "/"} path={tab.path}>
+                  <LivenetPlaceholder devOnly={tab.devOnly}>
+                    <tab.component />
+                  </LivenetPlaceholder>
+                </Route>
+              ))}
+              <Route>
+                <Balances />
               </Route>
-            ))}
-            <Route>
-              <Balances />
-            </Route>
-          </Switch>
-        </NestedRoutes>
-      </div>
-      <NewVersionNotice />
-    </Container>
+            </Switch>
+          </NestedRoutes>
+          <NewVersionNotice />
+        </Container>
+      </Sidebar>
+    </Box>
   );
 }

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -15,13 +15,14 @@ export function HomePage() {
       <Sidebar>
         <Container
           // sx={{ pl: `${DRAWER_WIDTH_MD}px` }}
+          sx={{ m: 0 }}
           disableGutters
           maxWidth="md"
         >
           <NestedRoutes base="/">
             <Switch>
               {TABS.map((tab) => (
-                <Route key={tab.path || "/"} path={tab.path}>
+                <Route key={tab.path} path={tab.path}>
                   <LivenetPlaceholder devOnly={tab.devOnly}>
                     <tab.component />
                   </LivenetPlaceholder>

--- a/gui/src/components/Navbar.tsx
+++ b/gui/src/components/Navbar.tsx
@@ -1,16 +1,7 @@
-import Settings from "@mui/icons-material/Settings";
-import { AppBar, Grid, IconButton, Toolbar } from "@mui/material";
-import { useState } from "react";
+import { AppBar, Grid, Toolbar } from "@mui/material";
 
 import { useTheme } from "../store";
-import {
-  Modal,
-  QuickAddressSelect,
-  QuickNetworkSelect,
-  QuickWalletSelect,
-  Settings as SettingsPage,
-} from "./";
-import { Logo } from "./Logo";
+import { QuickAddressSelect, QuickNetworkSelect, QuickWalletSelect } from "./";
 
 export function Navbar() {
   const palette = useTheme((s) => s.theme.palette);
@@ -25,7 +16,6 @@ export function Navbar() {
       }}
     >
       <Toolbar>
-        <Logo width={40} />
         <Grid
           container
           spacing={2}
@@ -41,34 +31,9 @@ export function Navbar() {
           <Grid item>
             <QuickNetworkSelect />
           </Grid>
-          <Grid item>
-            <SettingsButton />
-          </Grid>
+          <Grid item></Grid>
         </Grid>
       </Toolbar>
     </AppBar>
-  );
-}
-
-function SettingsButton() {
-  const [showSettings, setShowSettings] = useState(false);
-
-  return (
-    <>
-      <IconButton onClick={() => setShowSettings(true)}>
-        <Settings />
-      </IconButton>
-
-      <Modal
-        open={showSettings}
-        onClose={() => setShowSettings(false)}
-        sx={{
-          width: "80%",
-          height: "80%",
-        }}
-      >
-        <SettingsPage />
-      </Modal>
-    </>
   );
 }

--- a/gui/src/components/Navbar.tsx
+++ b/gui/src/components/Navbar.tsx
@@ -1,20 +1,27 @@
-import { AppBar, Toolbar } from "@mui/material";
+import { AppBar, Toolbar, Typography } from "@mui/material";
 
 import { useTheme } from "../store";
+import { TABS } from "./Sidebar";
 
-export function Navbar() {
+export function Navbar({ tab }: { tab: (typeof TABS)[number] }) {
   const palette = useTheme((s) => s.theme.palette);
 
   return (
     <AppBar
       position="sticky"
+      elevation={0}
       sx={{
         background: palette.background.default,
         color: palette.text.primary,
-        boxShadow: "none",
-        height: 32,
+        borderBottom: 1,
+        borderColor: palette.divider,
       }}
-      data-tauri-drag-region="true"
-    ></AppBar>
+    >
+      <Toolbar data-tauri-drag-region="true" variant="dense">
+        <Typography variant="h6" component="div">
+          {tab.name}
+        </Typography>
+      </Toolbar>
+    </AppBar>
   );
 }

--- a/gui/src/components/Navbar.tsx
+++ b/gui/src/components/Navbar.tsx
@@ -1,7 +1,6 @@
-import { AppBar, Grid, Toolbar } from "@mui/material";
+import { AppBar, Toolbar } from "@mui/material";
 
 import { useTheme } from "../store";
-import { QuickAddressSelect, QuickNetworkSelect, QuickWalletSelect } from "./";
 
 export function Navbar() {
   const palette = useTheme((s) => s.theme.palette);
@@ -13,27 +12,9 @@ export function Navbar() {
         background: palette.background.default,
         color: palette.text.primary,
         boxShadow: "none",
+        height: 32,
       }}
-    >
-      <Toolbar>
-        <Grid
-          container
-          spacing={2}
-          justifyContent="flex-end"
-          alignItems="center"
-        >
-          <Grid item>
-            <QuickWalletSelect />
-          </Grid>
-          <Grid item>
-            <QuickAddressSelect />
-          </Grid>
-          <Grid item>
-            <QuickNetworkSelect />
-          </Grid>
-          <Grid item></Grid>
-        </Grid>
-      </Toolbar>
-    </AppBar>
+      data-tauri-drag-region="true"
+    ></AppBar>
   );
 }

--- a/gui/src/components/QuickAddressSelect.tsx
+++ b/gui/src/components/QuickAddressSelect.tsx
@@ -1,4 +1,10 @@
-import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
 import { map } from "lodash-es";
 
 import { useInvoke } from "../hooks";
@@ -29,18 +35,24 @@ export function QuickAddressSelect() {
   if (!addresses || !currentWallet) return <>Loading</>;
 
   return (
-    <Select
-      size="small"
-      renderValue={renderValue}
-      value={getCurrentPath(currentWallet, addresses)}
-      onChange={handleChange}
-    >
-      {map(addresses, ([key, address]) => (
-        <MenuItem value={key} key={key}>
-          <AddressView contextMenu={false} address={address} />
-        </MenuItem>
-      ))}
-    </Select>
+    <FormControl variant="standard">
+      <InputLabel id="account-select-label">Account</InputLabel>
+      <Select
+        disableUnderline
+        label="Account"
+        labelId="account-select-label"
+        onChange={handleChange}
+        renderValue={renderValue}
+        size="small"
+        value={getCurrentPath(currentWallet, addresses)}
+      >
+        {map(addresses, ([key, address]) => (
+          <MenuItem value={key} key={key}>
+            <AddressView contextMenu={false} address={address} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 }
 

--- a/gui/src/components/QuickAddressSelect.tsx
+++ b/gui/src/components/QuickAddressSelect.tsx
@@ -35,10 +35,9 @@ export function QuickAddressSelect() {
   if (!addresses || !currentWallet) return <>Loading</>;
 
   return (
-    <FormControl variant="standard">
+    <FormControl fullWidth variant="standard">
       <InputLabel id="account-select-label">Account</InputLabel>
       <Select
-        disableUnderline
         label="Account"
         labelId="account-select-label"
         onChange={handleChange}

--- a/gui/src/components/QuickNetworkSelect.tsx
+++ b/gui/src/components/QuickNetworkSelect.tsx
@@ -1,4 +1,10 @@
-import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
 
 import { useNetworks } from "../store";
 
@@ -15,12 +21,22 @@ export function QuickNetworkSelect() {
   if (!networks || !current) return <>Loading</>;
 
   return (
-    <Select size="small" onChange={handleChange} value={current.name} label="">
-      {networks.map((network) => (
-        <MenuItem value={network.name} key={network.name}>
-          {network.name}
-        </MenuItem>
-      ))}
-    </Select>
+    <FormControl variant="standard">
+      <InputLabel id="network-select-label">Network</InputLabel>
+      <Select
+        labelId="network-select-label"
+        label="Network"
+        disableUnderline
+        size="small"
+        onChange={handleChange}
+        value={current.name}
+      >
+        {networks.map((network) => (
+          <MenuItem value={network.name} key={network.name}>
+            {network.name}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 }

--- a/gui/src/components/QuickNetworkSelect.tsx
+++ b/gui/src/components/QuickNetworkSelect.tsx
@@ -21,12 +21,11 @@ export function QuickNetworkSelect() {
   if (!networks || !current) return <>Loading</>;
 
   return (
-    <FormControl variant="standard">
+    <FormControl fullWidth variant="standard">
       <InputLabel id="network-select-label">Network</InputLabel>
       <Select
         labelId="network-select-label"
         label="Network"
-        disableUnderline
         size="small"
         onChange={handleChange}
         value={current.name}

--- a/gui/src/components/QuickWalletSelect.tsx
+++ b/gui/src/components/QuickWalletSelect.tsx
@@ -1,4 +1,10 @@
-import { MenuItem, Select, SelectChangeEvent } from "@mui/material";
+import {
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+} from "@mui/material";
 
 import { useWallets } from "../store";
 
@@ -16,12 +22,22 @@ export function QuickWalletSelect() {
   if (!wallets || !currentWallet) return <>Loading</>;
 
   return (
-    <Select size="small" value={currentWallet.name} onChange={handleChange}>
-      {wallets.map(({ name }) => (
-        <MenuItem value={name} key={name}>
-          {name}
-        </MenuItem>
-      ))}
-    </Select>
+    <FormControl variant="standard">
+      <InputLabel id="wallet-select-label">Wallet</InputLabel>
+      <Select
+        disableUnderline
+        label="Wallet"
+        labelId="wallet-select-label"
+        onChange={handleChange}
+        size="small"
+        value={currentWallet.name}
+      >
+        {wallets.map(({ name }) => (
+          <MenuItem value={name} key={name}>
+            {name}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
   );
 }

--- a/gui/src/components/QuickWalletSelect.tsx
+++ b/gui/src/components/QuickWalletSelect.tsx
@@ -22,10 +22,9 @@ export function QuickWalletSelect() {
   if (!wallets || !currentWallet) return <>Loading</>;
 
   return (
-    <FormControl variant="standard">
+    <FormControl variant="standard" fullWidth>
       <InputLabel id="wallet-select-label">Wallet</InputLabel>
       <Select
-        disableUnderline
         label="Wallet"
         labelId="wallet-select-label"
         onChange={handleChange}

--- a/gui/src/components/SettingsButton.tsx
+++ b/gui/src/components/SettingsButton.tsx
@@ -2,8 +2,8 @@ import Settings from "@mui/icons-material/SettingsSharp";
 import { Button, IconButton } from "@mui/material";
 import { useState } from "react";
 
-import { Modal, Settings as SettingsPage } from "./";
 import { useTheme } from "../store";
+import { Modal, Settings as SettingsPage } from "./";
 
 export function SettingsButton() {
   const [showSettings, setShowSettings] = useState(false);

--- a/gui/src/components/SettingsButton.tsx
+++ b/gui/src/components/SettingsButton.tsx
@@ -1,16 +1,40 @@
 import Settings from "@mui/icons-material/SettingsSharp";
-import { IconButton } from "@mui/material";
+import { Button, IconButton } from "@mui/material";
 import { useState } from "react";
+
 import { Modal, Settings as SettingsPage } from "./";
+import { useTheme } from "../store";
 
 export function SettingsButton() {
   const [showSettings, setShowSettings] = useState(false);
+  const { theme } = useTheme();
 
   return (
     <>
-      <IconButton onClick={() => setShowSettings(true)}>
+      <IconButton
+        onClick={() => setShowSettings(true)}
+        sx={{
+          display: "none",
+          [theme.breakpoints.down("md")]: {
+            display: "initial",
+          },
+        }}
+      >
         <Settings />
       </IconButton>
+
+      <Button
+        color="inherit"
+        startIcon={<Settings />}
+        onClick={() => setShowSettings(true)}
+        sx={{
+          [theme.breakpoints.down("md")]: {
+            display: "none",
+          },
+        }}
+      >
+        Settings
+      </Button>
 
       <Modal
         open={showSettings}

--- a/gui/src/components/SettingsButton.tsx
+++ b/gui/src/components/SettingsButton.tsx
@@ -1,0 +1,27 @@
+import Settings from "@mui/icons-material/SettingsSharp";
+import { IconButton } from "@mui/material";
+import { useState } from "react";
+import { Modal, Settings as SettingsPage } from "./";
+
+export function SettingsButton() {
+  const [showSettings, setShowSettings] = useState(false);
+
+  return (
+    <>
+      <IconButton onClick={() => setShowSettings(true)}>
+        <Settings />
+      </IconButton>
+
+      <Modal
+        open={showSettings}
+        onClose={() => setShowSettings(false)}
+        sx={{
+          width: "80%",
+          height: "80%",
+        }}
+      >
+        <SettingsPage />
+      </Modal>
+    </>
+  );
+}

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,0 +1,172 @@
+import {
+  Box,
+  Drawer,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import { findIndex } from "lodash-es";
+import { Link, useLocation, useRoute } from "wouter";
+import ArrowOutwardSharpIcon from "@mui/icons-material/ArrowOutwardSharp";
+import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
+import TerminalSharpIcon from "@mui/icons-material/TerminalSharp";
+import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
+import { parseInt, range, toString } from "lodash-es";
+
+import { useKeyPress, useMenuAction } from "../hooks";
+
+import { Balances, Contracts, Peers, Txs } from "./";
+
+import { Logo } from "./Logo";
+import { SettingsButton } from "./SettingsButton";
+import { ReactNode } from "react";
+import { useTheme } from "../store";
+
+export const TABS = [
+  {
+    path: "details",
+    name: "Balances",
+    component: Balances,
+    icon: RequestQuoteSharpIcon,
+  },
+  {
+    path: "transactions",
+    name: "Transactions",
+    component: Txs,
+    icon: ArrowOutwardSharpIcon,
+  },
+  {
+    path: "contracts",
+    name: "Contracts",
+    component: Contracts,
+    devOnly: true,
+    icon: TerminalSharpIcon,
+  },
+  {
+    path: "connections",
+    name: "Connections",
+    component: Peers,
+    icon: OnlinePredictionSharpIcon,
+  },
+];
+
+const WIDTH_MD = 200;
+const WIDTH_SM = 80;
+
+export function Sidebar({ children }: { children: ReactNode }) {
+  const [_match, params] = useRoute("/:path");
+  const [_location, setLocation] = useLocation();
+  const { theme } = useTheme();
+
+  const handleKeyboardNavigation = (event: KeyboardEvent) => {
+    setLocation(TABS[parseInt(event.key) - 1].path);
+  };
+
+  useMenuAction((payload) => setLocation(payload));
+
+  useKeyPress(
+    range(1, TABS.length + 1).map(toString),
+    { meta: true },
+    handleKeyboardNavigation
+  );
+
+  useKeyPress(
+    range(1, TABS.length + 1).map(toString),
+    { ctrl: true },
+    handleKeyboardNavigation
+  );
+
+  return (
+    <Box>
+      <Drawer
+        PaperProps={{
+          variant: "lighter",
+        }}
+        sx={{
+          flexShrink: 0,
+          "& .MuiDrawer-paper": {
+            width: WIDTH_MD,
+            [theme.breakpoints.down("md")]: {
+              width: WIDTH_SM,
+              justifyContent: "center",
+            },
+          },
+        }}
+        variant="permanent"
+      >
+        <Box
+          flexGrow={1}
+          display="flex"
+          flexDirection="column"
+          sx={{
+            [theme.breakpoints.down("md")]: {
+              alignItems: "center",
+            },
+          }}
+        >
+          <Box sx={{ px: 2, pt: 6 }}>
+            <Logo width={40} />
+          </Box>
+          <List sx={{ flexGrow: 1 }}>
+            {TABS.map((tab, index) => (
+              <ListItemButton
+                selected={
+                  index === Math.max(findIndex(TABS, { path: params?.path }), 0)
+                }
+                LinkComponent={Link}
+                href={tab.path}
+                key={tab.path}
+                sx={{
+                  minHeight: 50,
+                }}
+              >
+                <ListItemIcon
+                  sx={{
+                    [theme.breakpoints.down("md")]: {
+                      justifyContent: "center",
+                    },
+                  }}
+                >
+                  <tab.icon fontSize="medium" />
+                </ListItemIcon>
+                <ListItemText
+                  sx={{
+                    [theme.breakpoints.down("md")]: {
+                      display: "none",
+                    },
+                  }}
+                >
+                  {tab.name}
+                </ListItemText>
+              </ListItemButton>
+            ))}
+          </List>
+          <Box
+            p={2}
+            alignSelf="stretch"
+            display="flex"
+            justifyContent="flex-start"
+            sx={{
+              [theme.breakpoints.down("md")]: {
+                justifyContent: "center",
+              },
+            }}
+          >
+            <SettingsButton />
+          </Box>
+        </Box>
+      </Drawer>
+      <Box
+        sx={{
+          pl: `${WIDTH_MD}px`,
+          [theme.breakpoints.down("md")]: {
+            pl: `${WIDTH_SM}px`,
+          },
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Drawer,
+  Grid,
   List,
   ListItemButton,
   ListItemIcon,
@@ -16,7 +17,15 @@ import { parseInt, range, toString } from "lodash-es";
 
 import { useKeyPress, useMenuAction } from "../hooks";
 
-import { Balances, Contracts, Peers, Txs } from "./";
+import {
+  Balances,
+  Contracts,
+  Peers,
+  QuickAddressSelect,
+  QuickNetworkSelect,
+  QuickWalletSelect,
+  Txs,
+} from "./";
 
 import { Logo } from "./Logo";
 import { SettingsButton } from "./SettingsButton";
@@ -105,7 +114,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
             },
           }}
         >
-          <Box sx={{ px: 2, pt: 6 }}>
+          <Box flexShrink={0} sx={{ px: 2, pt: 6 }}>
             <Logo width={40} />
           </Box>
           <List sx={{ flexGrow: 1 }}>
@@ -142,6 +151,30 @@ export function Sidebar({ children }: { children: ReactNode }) {
               </ListItemButton>
             ))}
           </List>
+          <Grid
+            container
+            spacing={2}
+            justifyContent="center"
+            flexDirection="column"
+            alignItems="stretch"
+            sx={{
+              [theme.breakpoints.down("md")]: {
+                display: "none",
+              },
+            }}
+            p={2}
+          >
+            <Grid item>
+              <QuickWalletSelect />
+            </Grid>
+            <Grid item>
+              <QuickAddressSelect />
+            </Grid>
+            <Grid item>
+              <QuickNetworkSelect />
+            </Grid>
+            <Grid item></Grid>
+          </Grid>
           <Box
             p={2}
             alignSelf="stretch"

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -159,13 +159,12 @@ export function Sidebar({ children }: { children: ReactNode }) {
   );
 }
 
-function SidebarTab({
-  tab,
-  selected,
-}: {
+interface SidebarTabProps {
   tab: (typeof TABS)[number];
   selected: boolean;
-}) {
+}
+
+function SidebarTab({ tab, selected }: SidebarTabProps) {
   const { theme } = useTheme();
   const backgroundColor = theme.palette.mode === "dark" ? 800 : 200;
 

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation, useRoute } from "wouter";
 import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
 import TerminalSharpIcon from "@mui/icons-material/TerminalSharp";
 import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
+import CallToActionIcon from "@mui/icons-material/CallToAction";
 import ReceiptIcon from "@mui/icons-material/Receipt";
 import { parseInt, range, toString } from "lodash-es";
 
@@ -44,7 +45,7 @@ export const TABS = [
     name: "Contracts",
     component: Contracts,
     devOnly: true,
-    icon: TerminalSharpIcon,
+    icon: CallToActionIcon,
   },
   {
     path: "connections",

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,18 +1,10 @@
-import {
-  Box,
-  Drawer,
-  Grid,
-  List,
-  ListItemButton,
-  ListItemIcon,
-  ListItemText,
-} from "@mui/material";
+import { Box, Button, Drawer, IconButton, Stack } from "@mui/material";
 import { findIndex } from "lodash-es";
 import { Link, useLocation, useRoute } from "wouter";
-import ArrowOutwardSharpIcon from "@mui/icons-material/ArrowOutwardSharp";
 import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
 import TerminalSharpIcon from "@mui/icons-material/TerminalSharp";
 import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
+import ReceiptIcon from "@mui/icons-material/Receipt";
 import { parseInt, range, toString } from "lodash-es";
 
 import { useKeyPress, useMenuAction } from "../hooks";
@@ -31,6 +23,8 @@ import { Logo } from "./Logo";
 import { SettingsButton } from "./SettingsButton";
 import { ReactNode } from "react";
 import { useTheme } from "../store";
+import { CommandBarButton } from "./CommandBarButton";
+import { grey } from "@mui/material/colors";
 
 export const TABS = [
   {
@@ -43,7 +37,7 @@ export const TABS = [
     path: "transactions",
     name: "Transactions",
     component: Txs,
-    icon: ArrowOutwardSharpIcon,
+    icon: ReceiptIcon,
   },
   {
     path: "contracts",
@@ -91,10 +85,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
       <Drawer
         PaperProps={{
           variant: "lighter",
-        }}
-        sx={{
-          flexShrink: 0,
-          "& .MuiDrawer-paper": {
+          sx: {
             width: WIDTH_MD,
             [theme.breakpoints.down("md")]: {
               width: WIDTH_SM,
@@ -102,6 +93,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
             },
           },
         }}
+        sx={{ flexShrink: 0 }}
         variant="permanent"
       >
         <Box
@@ -117,77 +109,42 @@ export function Sidebar({ children }: { children: ReactNode }) {
           <Box flexShrink={0} sx={{ px: 2, pt: 6 }}>
             <Logo width={40} />
           </Box>
-          <List sx={{ flexGrow: 1 }}>
+          <Stack p={2} rowGap={1} flexGrow={1}>
             {TABS.map((tab, index) => (
-              <ListItemButton
+              <SidebarTab
+                key={index}
+                tab={tab}
                 selected={
                   index === Math.max(findIndex(TABS, { path: params?.path }), 0)
                 }
-                LinkComponent={Link}
-                href={tab.path}
-                key={tab.path}
-                sx={{
-                  minHeight: 50,
-                }}
-              >
-                <ListItemIcon
-                  sx={{
-                    [theme.breakpoints.down("md")]: {
-                      justifyContent: "center",
-                    },
-                  }}
-                >
-                  <tab.icon fontSize="medium" />
-                </ListItemIcon>
-                <ListItemText
-                  sx={{
-                    [theme.breakpoints.down("md")]: {
-                      display: "none",
-                    },
-                  }}
-                >
-                  {tab.name}
-                </ListItemText>
-              </ListItemButton>
+              />
             ))}
-          </List>
-          <Grid
-            container
-            spacing={2}
-            justifyContent="center"
-            flexDirection="column"
-            alignItems="stretch"
+          </Stack>
+          <Stack
+            rowGap={1}
+            p={2}
             sx={{
               [theme.breakpoints.down("md")]: {
                 display: "none",
               },
             }}
-            p={2}
           >
-            <Grid item>
-              <QuickWalletSelect />
-            </Grid>
-            <Grid item>
-              <QuickAddressSelect />
-            </Grid>
-            <Grid item>
-              <QuickNetworkSelect />
-            </Grid>
-            <Grid item></Grid>
-          </Grid>
-          <Box
+            <QuickWalletSelect />
+            <QuickAddressSelect />
+            <QuickNetworkSelect />
+          </Stack>
+          <Stack
             p={2}
-            alignSelf="stretch"
-            display="flex"
-            justifyContent="flex-start"
+            rowGap={1}
             sx={{
               [theme.breakpoints.down("md")]: {
                 justifyContent: "center",
               },
             }}
           >
+            <CommandBarButton />
             <SettingsButton />
-          </Box>
+          </Stack>
         </Box>
       </Drawer>
       <Box
@@ -201,5 +158,61 @@ export function Sidebar({ children }: { children: ReactNode }) {
         {children}
       </Box>
     </Box>
+  );
+}
+
+function SidebarTab({
+  tab,
+  selected,
+}: {
+  tab: (typeof TABS)[number];
+  selected: boolean;
+}) {
+  const { theme } = useTheme();
+  const backgroundColor = theme.palette.mode === "dark" ? 800 : 200;
+
+  return (
+    <>
+      <IconButton
+        LinkComponent={Link}
+        href={tab.path}
+        disabled={selected}
+        color="inherit"
+        size="small"
+        sx={{
+          display: "none",
+          height: 40,
+          width: 40,
+          [theme.breakpoints.down("md")]: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          },
+          "&.Mui-disabled": {
+            backgroundColor: grey[backgroundColor],
+          },
+        }}
+      >
+        <tab.icon fontSize="medium" />
+      </IconButton>
+      <Button
+        color="inherit"
+        disabled={selected}
+        startIcon={<tab.icon fontSize="medium" />}
+        LinkComponent={Link}
+        href={tab.path}
+        sx={{
+          justifyContent: "flex-start",
+          [theme.breakpoints.down("md")]: {
+            display: "none",
+          },
+          "&.Mui-disabled": {
+            backgroundColor: grey[backgroundColor],
+          },
+        }}
+      >
+        {tab.name}
+      </Button>
+    </>
   );
 }

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import { Box, Button, Drawer, IconButton, Stack } from "@mui/material";
 import { findIndex } from "lodash-es";
 import { Link, useLocation, useRoute } from "wouter";
 import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
-import TerminalSharpIcon from "@mui/icons-material/TerminalSharp";
 import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
 import CallToActionIcon from "@mui/icons-material/CallToAction";
 import ReceiptIcon from "@mui/icons-material/Receipt";

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -1,14 +1,16 @@
-import { Box, Button, Drawer, IconButton, Stack } from "@mui/material";
-import { findIndex } from "lodash-es";
-import { Link, useLocation, useRoute } from "wouter";
-import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
-import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
 import CallToActionIcon from "@mui/icons-material/CallToAction";
+import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
 import ReceiptIcon from "@mui/icons-material/Receipt";
+import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
+import { Box, Button, Drawer, IconButton, Stack } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import { findIndex } from "lodash-es";
 import { parseInt, range, toString } from "lodash-es";
+import { ReactNode } from "react";
+import { Link, useLocation, useRoute } from "wouter";
 
 import { useKeyPress, useMenuAction } from "../hooks";
-
+import { useTheme } from "../store";
 import {
   Balances,
   Contracts,
@@ -18,13 +20,9 @@ import {
   QuickWalletSelect,
   Txs,
 } from "./";
-
+import { CommandBarButton } from "./CommandBarButton";
 import { Logo } from "./Logo";
 import { SettingsButton } from "./SettingsButton";
-import { ReactNode } from "react";
-import { useTheme } from "../store";
-import { CommandBarButton } from "./CommandBarButton";
-import { grey } from "@mui/material/colors";
 
 export const TABS = [
   {

--- a/gui/src/global.d.ts
+++ b/gui/src/global.d.ts
@@ -3,3 +3,9 @@ import Chrome from "chrome";
 declare namespace chrome {
   export default Chrome;
 }
+
+declare module "@mui/material/Paper" {
+  interface PaperPropsVariantOverrides {
+    lighter: true;
+  }
+}

--- a/gui/src/store/networks.ts
+++ b/gui/src/store/networks.ts
@@ -52,6 +52,7 @@ const store: StateCreator<Store> = (set, get) => ({
     const current = await invoke<Network>("networks_get_current");
     const networks = await invoke<Network[]>("networks_get_list");
     set({ networks, current });
+    get().reloadActions();
   },
 
   async reloadActions() {

--- a/gui/src/store/theme.ts
+++ b/gui/src/store/theme.ts
@@ -1,10 +1,10 @@
-import { PaletteMode, Theme, createTheme } from "@mui/material";
+import { PaletteMode, Theme, ThemeOptions, createTheme } from "@mui/material";
 import { invoke } from "@tauri-apps/api/tauri";
 import { Action } from "kbar";
 import { StateCreator, create } from "zustand";
+import { grey } from "@mui/material/colors";
 
 import { GeneralSettings } from "../types";
-import { grey } from "@mui/material/colors";
 
 interface Store {
   mode: "auto" | "light" | "dark";
@@ -25,7 +25,6 @@ const store: StateCreator<Store> = (set, get) => ({
     {
       id: actionId,
       name: "Change theme mode",
-      section: "",
     },
     ...(["auto", "dark", "light"] as const).map((mode) => ({
       id: `${actionId}/${mode}`,
@@ -61,19 +60,12 @@ export const useTheme = create<Store>()(store);
   await useTheme.getState().reload();
 })();
 
-function getDesignTokens(mode: PaletteMode) {
+function getDesignTokens(mode: PaletteMode): ThemeOptions {
   const light = mode === "light";
 
   return {
     palette: {
       mode,
-      ...(light
-        ? {
-            background: {},
-          }
-        : {
-            background: {},
-          }),
     },
     components: {
       MuiPaper: {

--- a/gui/src/store/theme.ts
+++ b/gui/src/store/theme.ts
@@ -4,6 +4,7 @@ import { Action } from "kbar";
 import { StateCreator, create } from "zustand";
 
 import { GeneralSettings } from "../types";
+import { grey } from "@mui/material/colors";
 
 interface Store {
   mode: "auto" | "light" | "dark";
@@ -61,16 +62,30 @@ export const useTheme = create<Store>()(store);
 })();
 
 function getDesignTokens(mode: PaletteMode) {
+  const light = mode === "light";
+
   return {
     palette: {
       mode,
-      ...(mode === "light"
+      ...(light
         ? {
             background: {},
           }
         : {
             background: {},
           }),
+    },
+    components: {
+      MuiPaper: {
+        variants: [
+          {
+            props: { variant: "lighter" as const },
+            style: {
+              background: light ? grey[100] : grey[900],
+            },
+          },
+        ],
+      },
     },
   };
 }

--- a/gui/src/store/theme.ts
+++ b/gui/src/store/theme.ts
@@ -1,8 +1,8 @@
 import { PaletteMode, Theme, ThemeOptions, createTheme } from "@mui/material";
+import { grey } from "@mui/material/colors";
 import { invoke } from "@tauri-apps/api/tauri";
 import { Action } from "kbar";
 import { StateCreator, create } from "zustand";
-import { grey } from "@mui/material/colors";
 
 import { GeneralSettings } from "../types";
 

--- a/gui/src/store/wallets.ts
+++ b/gui/src/store/wallets.ts
@@ -67,24 +67,20 @@ const store: StateCreator<Store> = (set, get) => ({
 
   async reloadActions() {
     const { wallets } = get();
-    const info = await fetchAllWalletInfo(wallets);
+    const info = (await fetchAllWalletInfo(wallets)) || [];
 
     const actions = [
       {
         id: actionId,
         name: "Change wallet",
       },
-      // create action for each wallet
-      ...(info || [])
+      ...info
         .map(({ wallet, addresses }) => [
           {
             id: `${actionId}/${wallet.name}`,
             name: wallet.name,
             parent: actionId,
-            perform: () => get().setCurrentWallet(wallet.name),
           },
-
-          // create action for each address
           ...(addresses || []).map(({ key, address, alias }) => ({
             id: `${actionId}/${wallet.name}/${key}`,
             name: alias || address,
@@ -96,13 +92,6 @@ const store: StateCreator<Store> = (set, get) => ({
           })),
         ])
         .flat(),
-
-      ...(wallets || []).map(({ name }) => ({
-        id: `${actionId}/${name}`,
-        name,
-        parent: actionId,
-        perform: () => get().setCurrentWallet(name),
-      })),
     ];
 
     set({ actions });


### PR DESCRIPTION
In this change, we replace the tabs with a sidebar. The goal is to make Iron look more like any other desktop app while at the same time making the UI more self-explanatory.

We are also moving the dropdown selectors for wallet, address, and network to the sidebar. They have labels to make them easy to figure out, and the style change so they are less "present" in the UI.

The sidebar also has a compact mode, where the text and dropdown disappear, and we are left with just icons. This mode is nice for those who don't want Iron taking up a lot of space and only need to look up small bits of information or perform short interactions. The dropdowns disappear, but we still have the button for the command bar that can be used to click around and perform actions like changing network, wallet, or address.

The navbar also got some updates to make it look more like a native app.

There are other minor fixes across the codebase.

<img width="1324" alt="Screenshot 2023-08-03 at 18 00 39" src="https://github.com/iron-wallet/iron/assets/934580/81a6ca99-fb24-4529-a22e-19179e467e65">
<img width="458" alt="Screenshot 2023-08-03 at 18 01 02" src="https://github.com/iron-wallet/iron/assets/934580/37da5cd2-a057-4a88-8f73-7f09d8337305">
