### PR TITLE
Fixes sidebar's HMR

### DIFF
--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -2,9 +2,7 @@ import { Box } from "@mui/material";
 import { Route, Switch } from "wouter";
 
 import { LivenetPlaceholder, Navbar, NestedRoutes, NewVersionNotice } from "./";
-import { Sidebar, TABS } from "./Sidebar";
-
-const defaultTab = TABS[0];
+import { DEFAULT_TAB, Sidebar, TABS } from "./Sidebar";
 
 export function HomePage() {
   return (
@@ -23,8 +21,8 @@ export function HomePage() {
               </Route>
             ))}
             <Route>
-              <Navbar tab={defaultTab} />
-              <defaultTab.component />
+              <Navbar tab={DEFAULT_TAB} />
+              <DEFAULT_TAB.component />
             </Route>
           </Switch>
         </NestedRoutes>

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -52,6 +52,8 @@ export const TABS = [
   },
 ];
 
+export const DEFAULT_TAB = TABS[0];
+
 const WIDTH_MD = 200;
 const WIDTH_SM = 80;
 
@@ -104,7 +106,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
             },
           }}
         >
-          <Box flexShrink={0} sx={{ px: 2, pt: 6 }}>
+          <Box flexShrink={0} sx={{ px: 2, pt: 2 }}>
             <Logo width={40} />
           </Box>
           <Stack p={2} rowGap={1} flexGrow={1}>


### PR DESCRIPTION
whenever the sidebar was edited and hot-reloaded, an error would be thrown about `TABS[0]` being uninitialized. This seems to fix it

cc/ @gabrielpoca 