### PR TITLE
Several chores I've been piling up

### DIFF
--- a/bin/iron/tauri.conf.json
+++ b/bin/iron/tauri.conf.json
@@ -48,8 +48,8 @@
         "fullscreen": false,
         "resizable": true,
         "title": "",
-        "width": 1200,
-        "height": 800,
+        "width": 600,
+        "height": 700,
         "titleBarStyle": "Overlay"
       }
     ]

--- a/gui/src/components/Account.tsx
+++ b/gui/src/components/Account.tsx
@@ -11,7 +11,7 @@ import {
 import { useTheme, useWallets } from "../store";
 import { AddressView, BalancesList, Panel } from "./";
 
-export function Balances() {
+export function Account() {
   const { theme } = useTheme();
   const address = useWallets((s) => s.address);
 

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -1,33 +1,31 @@
-import { Box } from "@mui/material";
 import { Route, Switch } from "wouter";
 
 import { LivenetPlaceholder, Navbar, NestedRoutes, NewVersionNotice } from "./";
-import { DEFAULT_TAB, Sidebar, TABS } from "./Sidebar";
+import { DEFAULT_TAB, Sidebar, SidebarLayout, TABS } from "./Sidebar";
 
 export function HomePage() {
   return (
-    <Box>
-      <Sidebar>
-        <NestedRoutes base="/">
-          <Switch>
-            {TABS.map((tab) => (
-              <Route key={tab.path} path={tab.path}>
-                <>
-                  <Navbar tab={tab} />
-                  <LivenetPlaceholder devOnly={tab.devOnly}>
-                    <tab.component />
-                  </LivenetPlaceholder>
-                </>
-              </Route>
-            ))}
-            <Route>
-              <Navbar tab={DEFAULT_TAB} />
-              <DEFAULT_TAB.component />
+    <SidebarLayout>
+      <Sidebar />
+      <NestedRoutes base="/">
+        <Switch>
+          {TABS.map((tab) => (
+            <Route key={tab.path} path={tab.path}>
+              <>
+                <Navbar tab={tab} />
+                <LivenetPlaceholder devOnly={tab.devOnly}>
+                  <tab.component />
+                </LivenetPlaceholder>
+              </>
             </Route>
-          </Switch>
-        </NestedRoutes>
-        <NewVersionNotice />
-      </Sidebar>
-    </Box>
+          ))}
+          <Route>
+            <Navbar tab={DEFAULT_TAB} />
+            <DEFAULT_TAB.component />
+          </Route>
+        </Switch>
+      </NestedRoutes>
+      <NewVersionNotice />
+    </SidebarLayout>
   );
 }

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ import { Link, useLocation, useRoute } from "wouter";
 import { useKeyPress, useMenuAction } from "../hooks";
 import { useTheme } from "../store";
 import {
-  Balances,
+  Account,
   Contracts,
   Peers,
   QuickAddressSelect,
@@ -26,9 +26,9 @@ import { SettingsButton } from "./SettingsButton";
 
 export const TABS = [
   {
-    path: "details",
-    name: "Balances",
-    component: Balances,
+    path: "account",
+    name: "Account",
+    component: Account,
     icon: RequestQuoteSharpIcon,
   },
   {
@@ -57,10 +57,10 @@ export const DEFAULT_TAB = TABS[0];
 const WIDTH_MD = 200;
 const WIDTH_SM = 80;
 
-export function Sidebar({ children }: { children: ReactNode }) {
-  const [_match, params] = useRoute("/:path");
+export function SidebarLayout({ children }: { children: ReactNode }) {
   const [_location, setLocation] = useLocation();
   const { theme } = useTheme();
+  const breakpoint = theme.breakpoints.down("sm");
 
   const handleKeyboardNavigation = (event: KeyboardEvent) => {
     setLocation(TABS[parseInt(event.key) - 1].path);
@@ -81,83 +81,112 @@ export function Sidebar({ children }: { children: ReactNode }) {
   );
 
   return (
-    <Box>
-      <Drawer
-        PaperProps={{
-          variant: "lighter",
-          sx: {
-            width: WIDTH_MD,
-            [theme.breakpoints.down("md")]: {
-              width: WIDTH_SM,
-              justifyContent: "center",
-            },
-          },
-        }}
-        sx={{ flexShrink: 0 }}
-        variant="permanent"
-      >
-        <Box
-          flexGrow={1}
-          display="flex"
-          flexDirection="column"
-          sx={{
-            [theme.breakpoints.down("md")]: {
-              alignItems: "center",
-            },
-          }}
-        >
-          <Box flexShrink={0} sx={{ px: 2, pt: 2 }}>
-            <Logo width={40} />
-          </Box>
-          <Stack p={2} rowGap={1} flexGrow={1}>
-            {TABS.map((tab, index) => (
-              <SidebarTab
-                key={index}
-                tab={tab}
-                selected={
-                  index === Math.max(findIndex(TABS, { path: params?.path }), 0)
-                }
-              />
-            ))}
-          </Stack>
-          <Stack
-            rowGap={1}
-            p={2}
-            sx={{
-              [theme.breakpoints.down("md")]: {
-                display: "none",
-              },
-            }}
-          >
-            <QuickWalletSelect />
-            <QuickAddressSelect />
-            <QuickNetworkSelect />
-          </Stack>
-          <Stack
-            p={2}
-            rowGap={1}
-            sx={{
-              [theme.breakpoints.down("md")]: {
-                justifyContent: "center",
-              },
-            }}
-          >
-            <CommandBarButton />
-            <SettingsButton />
-          </Stack>
-        </Box>
-      </Drawer>
+    <>
+      <Sidebar />
       <Box
         sx={{
           pl: `${WIDTH_MD}px`,
-          [theme.breakpoints.down("md")]: {
+          [breakpoint]: {
             pl: `${WIDTH_SM}px`,
           },
         }}
       >
         {children}
       </Box>
-    </Box>
+    </>
+  );
+}
+
+export function Sidebar() {
+  const [_match, params] = useRoute("/:path");
+  const [_location, setLocation] = useLocation();
+  const { theme } = useTheme();
+  const breakpoint = theme.breakpoints.down("sm");
+
+  const handleKeyboardNavigation = (event: KeyboardEvent) => {
+    setLocation(TABS[parseInt(event.key) - 1].path);
+  };
+
+  useMenuAction((payload) => setLocation(payload));
+
+  useKeyPress(
+    range(1, TABS.length + 1).map(toString),
+    { meta: true },
+    handleKeyboardNavigation
+  );
+
+  useKeyPress(
+    range(1, TABS.length + 1).map(toString),
+    { ctrl: true },
+    handleKeyboardNavigation
+  );
+
+  return (
+    <Drawer
+      PaperProps={{
+        variant: "lighter",
+        sx: {
+          width: WIDTH_MD,
+          [breakpoint]: {
+            width: WIDTH_SM,
+            justifyContent: "center",
+          },
+        },
+      }}
+      sx={{ flexShrink: 0 }}
+      variant="permanent"
+    >
+      <Box
+        flexGrow={1}
+        display="flex"
+        flexDirection="column"
+        sx={{
+          [breakpoint]: {
+            alignItems: "center",
+          },
+        }}
+      >
+        <Box flexShrink={0} sx={{ px: 2, pt: 2 }}>
+          <Logo width={40} />
+        </Box>
+        <Stack p={2} rowGap={1} flexGrow={1}>
+          {TABS.map((tab, index) => (
+            <SidebarTab
+              key={index}
+              tab={tab}
+              selected={
+                index === Math.max(findIndex(TABS, { path: params?.path }), 0)
+              }
+            />
+          ))}
+        </Stack>
+        <Stack
+          rowGap={1}
+          p={2}
+          sx={{
+            [breakpoint]: {
+              display: "none",
+            },
+          }}
+        >
+          <QuickWalletSelect />
+          <QuickAddressSelect />
+          <QuickNetworkSelect />
+        </Stack>
+        <Stack
+          p={2}
+          rowGap={1}
+          sx={{
+            [breakpoint]: {
+              justifyContent: "center",
+            },
+          }}
+        >
+          <CommandBarButton />
+          <SettingsButton />
+        </Stack>
+      </Box>
+    </Drawer>
   );
 }
 
@@ -169,6 +198,7 @@ interface SidebarTabProps {
 function SidebarTab({ tab, selected }: SidebarTabProps) {
   const { theme } = useTheme();
   const backgroundColor = theme.palette.mode === "dark" ? 800 : 200;
+  const breakpoint = theme.breakpoints.down("sm");
 
   return (
     <>
@@ -182,7 +212,7 @@ function SidebarTab({ tab, selected }: SidebarTabProps) {
           display: "none",
           height: 40,
           width: 40,
-          [theme.breakpoints.down("md")]: {
+          [breakpoint]: {
             display: "flex",
             alignItems: "center",
             justifyContent: "center",
@@ -202,7 +232,7 @@ function SidebarTab({ tab, selected }: SidebarTabProps) {
         href={tab.path}
         sx={{
           justifyContent: "flex-start",
-          [theme.breakpoints.down("md")]: {
+          [breakpoint]: {
             display: "none",
           },
           "&.Mui-disabled": {

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -1,6 +1,6 @@
 export { ABIForm } from "./ABIForm";
 export { AddressView } from "./AddressView";
-export { Balances } from "./Balances";
+export { Account } from "./Account";
 export { BalancesList } from "./BalancesList";
 export { CommandBar } from "./CommandBar";
 export { ConfirmationDialog } from "./ConfirmationDialog";

--- a/gui/src/global.d.ts
+++ b/gui/src/global.d.ts
@@ -1,3 +1,4 @@
+import { BreakpointOverrides } from "@mui/material/styles";
 import Chrome from "chrome";
 
 declare namespace chrome {
@@ -7,5 +8,12 @@ declare namespace chrome {
 declare module "@mui/material/Paper" {
   interface PaperPropsVariantOverrides {
     lighter: true;
+  }
+}
+
+// https://github.com/mui/material-ui/issues/35251#issuecomment-1366844584
+declare module "@mui/material/styles" {
+  interface BreakpointOverrides {
+    sidebar: true;
   }
 }

--- a/gui/src/global.d.ts
+++ b/gui/src/global.d.ts
@@ -10,10 +10,3 @@ declare module "@mui/material/Paper" {
     lighter: true;
   }
 }
-
-// https://github.com/mui/material-ui/issues/35251#issuecomment-1366844584
-declare module "@mui/material/styles" {
-  interface BreakpointOverrides {
-    sidebar: true;
-  }
-}

--- a/gui/src/store/theme.ts
+++ b/gui/src/store/theme.ts
@@ -64,6 +64,16 @@ function getDesignTokens(mode: PaletteMode): ThemeOptions {
   const light = mode === "light";
 
   return {
+    breakpoints: {
+      values: {
+        xs: 0,
+        sm: 600,
+        md: 900,
+        lg: 1200,
+        xl: 1536,
+        sidebar: 100,
+      },
+    },
     palette: {
       mode,
     },

--- a/gui/src/store/theme.ts
+++ b/gui/src/store/theme.ts
@@ -64,16 +64,6 @@ function getDesignTokens(mode: PaletteMode): ThemeOptions {
   const light = mode === "light";
 
   return {
-    breakpoints: {
-      values: {
-        xs: 0,
-        sm: 600,
-        md: 900,
-        lg: 1200,
-        xl: 1536,
-        sidebar: 100,
-      },
-    },
     palette: {
       mode,
     },


### PR DESCRIPTION
- Refactors sidebar to size down on `sm` breakpoint instead of `md` (makes more sense visually to me. the previous version left a lot of empty space on the right
- changes `Details` to `Account`, since the previous name no longer makes sense 
- Refactors Sidebar to no longer wrap the content (which semantically speaking was weird)
- makes the default window size smaller