### PR TITLE
Sidebars and Toolbars

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from "@mui/material";
+import { GlobalStyles, ThemeProvider } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Route, Router, Switch } from "wouter";
@@ -18,11 +18,20 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { suspense: true } },
 });
 
+const globalStyles = {
+  body: { userSelect: "none" },
+  p: { userSelect: "initial" },
+  h1: { userSelect: "initial" },
+  h2: { userSelect: "initial" },
+  h3: { userSelect: "initial" },
+};
+
 export default function App() {
   const theme = useTheme((s) => s.theme);
 
   return (
     <ThemeProvider theme={theme}>
+      <GlobalStyles styles={globalStyles} />
       <CssBaseline>
         <QueryClientProvider client={queryClient}>
           <OnboardingWrapper>

--- a/gui/src/components/CommandBarButton.tsx
+++ b/gui/src/components/CommandBarButton.tsx
@@ -19,7 +19,7 @@ export function CommandBarButton() {
           height: 40,
           width: 40,
           display: "none",
-          [theme.breakpoints.down("md")]: {
+          [theme.breakpoints.down("sm")]: {
             display: "initial",
           },
         }}
@@ -34,7 +34,7 @@ export function CommandBarButton() {
         onClick={handleClick}
         sx={{
           justifyContent: "flex-start",
-          [theme.breakpoints.down("md")]: {
+          [theme.breakpoints.down("sm")]: {
             display: "none",
           },
         }}

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -1,12 +1,11 @@
 import { Route, Switch } from "wouter";
 
 import { LivenetPlaceholder, Navbar, NestedRoutes, NewVersionNotice } from "./";
-import { DEFAULT_TAB, Sidebar, SidebarLayout, TABS } from "./Sidebar";
+import { DEFAULT_TAB, SidebarLayout, TABS } from "./Sidebar";
 
 export function HomePage() {
   return (
     <SidebarLayout>
-      <Sidebar />
       <NestedRoutes base="/">
         <Switch>
           {TABS.map((tab) => (

--- a/gui/src/components/Navbar.tsx
+++ b/gui/src/components/Navbar.tsx
@@ -17,7 +17,7 @@ export function Navbar({ tab }: { tab: (typeof TABS)[number] }) {
         borderColor: palette.divider,
       }}
     >
-      <Toolbar data-tauri-drag-region="true" variant="dense">
+      <Toolbar data-tauri-drag-region="true">
         <Typography variant="h6" component="div">
           {tab.name}
         </Typography>

--- a/gui/src/components/Onboarding/Wizard.tsx
+++ b/gui/src/components/Onboarding/Wizard.tsx
@@ -3,8 +3,7 @@ import { invoke } from "@tauri-apps/api/tauri";
 import { useEffect, useState } from "react";
 
 import { GeneralSettings } from "../../types";
-import { Logo } from "../Logo";
-import { useInvoke, useKeyPress, useOS } from "./../../hooks";
+import { useInvoke, useKeyPress } from "./../../hooks";
 import { OnboardingCarousel } from "./Carousel";
 import { steps } from "./Steps";
 
@@ -16,7 +15,6 @@ export type WizardFormData = { alchemyApiKey?: string | null };
 
 export function OnboardingWizard({ closeOnboarding }: Props) {
   const { data: settings } = useInvoke<GeneralSettings>("settings_get");
-  const { type } = useOS();
 
   const [activeStep, setActiveStep] = useState(0);
   const [formData, setFormData] = useState<WizardFormData>({});
@@ -53,11 +51,6 @@ export function OnboardingWizard({ closeOnboarding }: Props) {
   return (
     <Box px={3}>
       <Box data-tauri-drag-region="true" pt={4}></Box>
-      {type !== "Darwin" && (
-        <Box>
-          <Logo width={40} />
-        </Box>
-      )}
       <OnboardingCarousel
         steps={steps}
         activeStep={activeStep}

--- a/gui/src/components/Onboarding/Wizard.tsx
+++ b/gui/src/components/Onboarding/Wizard.tsx
@@ -1,10 +1,10 @@
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button } from "@mui/material";
 import { invoke } from "@tauri-apps/api/tauri";
 import { useEffect, useState } from "react";
 
 import { GeneralSettings } from "../../types";
 import { Logo } from "../Logo";
-import { useInvoke, useKeyPress } from "./../../hooks";
+import { useInvoke, useKeyPress, useOS } from "./../../hooks";
 import { OnboardingCarousel } from "./Carousel";
 import { steps } from "./Steps";
 
@@ -16,6 +16,7 @@ export type WizardFormData = { alchemyApiKey?: string | null };
 
 export function OnboardingWizard({ closeOnboarding }: Props) {
   const { data: settings } = useInvoke<GeneralSettings>("settings_get");
+  const { type } = useOS();
 
   const [activeStep, setActiveStep] = useState(0);
   const [formData, setFormData] = useState<WizardFormData>({});
@@ -51,10 +52,12 @@ export function OnboardingWizard({ closeOnboarding }: Props) {
 
   return (
     <Box px={3}>
-      <Stack direction="row" py={1.5} spacing={1} alignItems="center">
-        <Logo width={40} />
-        <Typography>Iron Wallet</Typography>
-      </Stack>
+      <Box data-tauri-drag-region="true" pt={4}></Box>
+      {type !== "Darwin" && (
+        <Box>
+          <Logo width={40} />
+        </Box>
+      )}
       <OnboardingCarousel
         steps={steps}
         activeStep={activeStep}

--- a/gui/src/components/Settings/Settings.tsx
+++ b/gui/src/components/Settings/Settings.tsx
@@ -22,7 +22,7 @@ export function Settings() {
   const tab = find(TABS, { name: currentTab });
 
   return (
-    <Container disableGutters>
+    <Container sx={{ margin: "initial" }} disableGutters>
       <Drawer
         PaperProps={{
           variant: "lighter",

--- a/gui/src/components/Settings/Settings.tsx
+++ b/gui/src/components/Settings/Settings.tsx
@@ -1,36 +1,87 @@
-import { Container, Tab, Tabs } from "@mui/material";
+import { Box, Button, Container, Drawer, Stack } from "@mui/material";
 import { useState } from "react";
 
-import { TabPanel } from "../";
 import { SettingsGeneral } from "./General";
 import { SettingsNetwork } from "./Network";
 import { SettingsWallets } from "./Wallets";
+import { grey } from "@mui/material/colors";
+import { useTheme } from "../../store";
+import { find } from "lodash-es";
 
-const tabs = [
+const TABS = [
   { name: "General", component: SettingsGeneral },
   { name: "Wallets", component: SettingsWallets },
   { name: "Network", component: SettingsNetwork },
 ];
 
+const WIDTH = 120;
+
 export function Settings() {
-  const [currentTab, setCurrentTab] = useState(0);
+  const [currentTab, setCurrentTab] = useState(TABS[0].name);
+
+  const tab = find(TABS, { name: currentTab });
 
   return (
-    <Container disableGutters maxWidth="md">
-      <Tabs
-        sx={{ mb: 2 }}
-        value={currentTab}
-        onChange={(_e, newTab) => setCurrentTab(newTab)}
+    <Container disableGutters>
+      <Drawer
+        PaperProps={{
+          variant: "lighter",
+          sx: {
+            width: WIDTH,
+          },
+        }}
+        sx={{ flexShrink: 0 }}
+        variant="permanent"
       >
-        {tabs.map((tab) => (
-          <Tab key={tab.name} label={tab.name} />
-        ))}
-      </Tabs>
-      {tabs.map((tab, index) => (
-        <TabPanel index={index} key={tab.name} value={currentTab}>
-          <tab.component />
-        </TabPanel>
-      ))}
+        <Box flexGrow={1} display="flex" flexDirection="column">
+          <Stack p={2} rowGap={1} flexGrow={1}>
+            {TABS.map((tab) => (
+              <SidebarTab
+                key={tab.name}
+                tab={tab}
+                selected={tab.name === currentTab}
+                onSelect={() => setCurrentTab(tab.name)}
+              />
+            ))}
+          </Stack>
+        </Box>
+      </Drawer>
+      <Box
+        sx={{
+          maxWidth: `calc(100% - ${WIDTH}px)`,
+          ml: `${WIDTH}px`,
+          width: "100%",
+        }}
+      >
+        {tab && <tab.component />}
+      </Box>
     </Container>
+  );
+}
+
+interface SidebarTabProps {
+  tab: (typeof TABS)[number];
+  selected: boolean;
+  onSelect: () => unknown;
+}
+
+function SidebarTab({ tab, onSelect, selected }: SidebarTabProps) {
+  const { theme } = useTheme();
+  const backgroundColor = theme.palette.mode === "dark" ? 800 : 200;
+
+  return (
+    <Button
+      color="inherit"
+      disabled={selected}
+      onClick={onSelect}
+      sx={{
+        justifyContent: "flex-start",
+        "&.Mui-disabled": {
+          backgroundColor: grey[backgroundColor],
+        },
+      }}
+    >
+      {tab.name}
+    </Button>
   );
 }

--- a/gui/src/components/Settings/Settings.tsx
+++ b/gui/src/components/Settings/Settings.tsx
@@ -1,12 +1,12 @@
 import { Box, Button, Container, Drawer, Stack } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import { find } from "lodash-es";
 import { useState } from "react";
 
+import { useTheme } from "../../store";
 import { SettingsGeneral } from "./General";
 import { SettingsNetwork } from "./Network";
 import { SettingsWallets } from "./Wallets";
-import { grey } from "@mui/material/colors";
-import { useTheme } from "../../store";
-import { find } from "lodash-es";
 
 const TABS = [
   { name: "General", component: SettingsGeneral },

--- a/gui/src/components/SettingsButton.tsx
+++ b/gui/src/components/SettingsButton.tsx
@@ -45,8 +45,8 @@ export function SettingsButton() {
         open={showSettings}
         onClose={() => setShowSettings(false)}
         sx={{
-          width: "80%",
-          height: "80%",
+          width: "90%",
+          height: "90%",
         }}
       >
         <SettingsPage />

--- a/gui/src/components/SettingsButton.tsx
+++ b/gui/src/components/SettingsButton.tsx
@@ -18,7 +18,7 @@ export function SettingsButton() {
           height: 40,
           width: 40,
           display: "none",
-          [theme.breakpoints.down("md")]: {
+          [theme.breakpoints.down("sm")]: {
             display: "initial",
           },
         }}
@@ -33,7 +33,7 @@ export function SettingsButton() {
         onClick={() => setShowSettings(true)}
         sx={{
           justifyContent: "flex-start",
-          [theme.breakpoints.down("md")]: {
+          [theme.breakpoints.down("sm")]: {
             display: "none",
           },
         }}

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ import { parseInt, range, toString } from "lodash-es";
 import { ReactNode } from "react";
 import { Link, useLocation, useRoute } from "wouter";
 
-import { useKeyPress, useMenuAction } from "../hooks";
+import { useKeyPress, useMenuAction, useOS } from "../hooks";
 import { useTheme } from "../store";
 import {
   Account,
@@ -102,6 +102,7 @@ export function Sidebar() {
   const [_location, setLocation] = useLocation();
   const { theme } = useTheme();
   const breakpoint = theme.breakpoints.down("sm");
+  const { type } = useOS();
 
   const handleKeyboardNavigation = (event: KeyboardEvent) => {
     setLocation(TABS[parseInt(event.key) - 1].path);
@@ -136,56 +137,58 @@ export function Sidebar() {
       sx={{ flexShrink: 0 }}
       variant="permanent"
     >
-      <Box
-        flexGrow={1}
-        display="flex"
-        flexDirection="column"
-        sx={{
-          [breakpoint]: {
-            alignItems: "center",
-          },
-        }}
-      >
-        <Box flexShrink={0} sx={{ px: 2, pt: 2 }}>
-          <Logo width={40} />
+      {type && (
+        <Box
+          flexGrow={1}
+          display="flex"
+          flexDirection="column"
+          sx={{
+            [breakpoint]: {
+              alignItems: "center",
+            },
+          }}
+        >
+          <Box flexShrink={0} sx={{ px: 2, pt: 2 }}>
+            {type !== "Darwin" && <Logo width={40} />}
+          </Box>
+          <Stack p={2} rowGap={1} flexGrow={1}>
+            {TABS.map((tab, index) => (
+              <SidebarTab
+                key={index}
+                tab={tab}
+                selected={
+                  index === Math.max(findIndex(TABS, { path: params?.path }), 0)
+                }
+              />
+            ))}
+          </Stack>
+          <Stack
+            rowGap={1}
+            p={2}
+            sx={{
+              [breakpoint]: {
+                display: "none",
+              },
+            }}
+          >
+            <QuickWalletSelect />
+            <QuickAddressSelect />
+            <QuickNetworkSelect />
+          </Stack>
+          <Stack
+            p={2}
+            rowGap={1}
+            sx={{
+              [breakpoint]: {
+                justifyContent: "center",
+              },
+            }}
+          >
+            <CommandBarButton />
+            <SettingsButton />
+          </Stack>
         </Box>
-        <Stack p={2} rowGap={1} flexGrow={1}>
-          {TABS.map((tab, index) => (
-            <SidebarTab
-              key={index}
-              tab={tab}
-              selected={
-                index === Math.max(findIndex(TABS, { path: params?.path }), 0)
-              }
-            />
-          ))}
-        </Stack>
-        <Stack
-          rowGap={1}
-          p={2}
-          sx={{
-            [breakpoint]: {
-              display: "none",
-            },
-          }}
-        >
-          <QuickWalletSelect />
-          <QuickAddressSelect />
-          <QuickNetworkSelect />
-        </Stack>
-        <Stack
-          p={2}
-          rowGap={1}
-          sx={{
-            [breakpoint]: {
-              justifyContent: "center",
-            },
-          }}
-        >
-          <CommandBarButton />
-          <SettingsButton />
-        </Stack>
-      </Box>
+      )}
     </Drawer>
   );
 }

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import CallToActionIcon from "@mui/icons-material/CallToAction";
 import OnlinePredictionSharpIcon from "@mui/icons-material/OnlinePredictionSharp";
 import ReceiptIcon from "@mui/icons-material/Receipt";
 import RequestQuoteSharpIcon from "@mui/icons-material/RequestQuoteSharp";
-import { Box, Button, Drawer, IconButton, Stack } from "@mui/material";
+import { Box, Button, Drawer, IconButton, Stack, Toolbar } from "@mui/material";
 import { grey } from "@mui/material/colors";
 import { findIndex } from "lodash-es";
 import { parseInt, range, toString } from "lodash-es";
@@ -148,10 +148,14 @@ export function Sidebar() {
             },
           }}
         >
-          <Box flexShrink={0} sx={{ px: 2, pt: 2 }}>
-            {type !== "Darwin" && <Logo width={40} />}
-          </Box>
-          <Stack p={2} rowGap={1} flexGrow={1}>
+          {type === "Darwin" ? (
+            <Toolbar data-tauri-drag-region="true"></Toolbar>
+          ) : (
+            <Toolbar sx={{ p: 2 }} data-tauri-drag-region="true">
+              <Logo width={40} />
+            </Toolbar>
+          )}
+          <Stack px={2} pb={2} pt={1} rowGap={1} flexGrow={1}>
             {TABS.map((tab, index) => (
               <SidebarTab
                 key={index}

--- a/gui/src/hooks/index.ts
+++ b/gui/src/hooks/index.ts
@@ -6,3 +6,4 @@ export { useRefreshPeers } from "./useRefreshPeers";
 export { useRefreshTransactions } from "./useRefreshTransactions";
 export { useDialog } from "./useDialog";
 export { useKeyPress } from "./useKeyPress";
+export { useOS } from "./useOS";

--- a/gui/src/hooks/useOS.ts
+++ b/gui/src/hooks/useOS.ts
@@ -2,7 +2,7 @@ import * as os from "@tauri-apps/api/os";
 import { useEffect, useState } from "react";
 
 export function useOS() {
-  const [type, setType] = useState<string | undefined>();
+  const [type, setType] = useState<os.OsType | undefined>();
 
   useEffect(() => {
     (async () => {

--- a/gui/src/hooks/useOS.ts
+++ b/gui/src/hooks/useOS.ts
@@ -1,0 +1,14 @@
+import * as os from "@tauri-apps/api/os";
+import { useEffect, useState } from "react";
+
+export function useOS() {
+  const [type, setType] = useState<string | undefined>();
+
+  useEffect(() => {
+    (async () => {
+      setType(await os.type());
+    })();
+  }, []);
+
+  return { type };
+}

--- a/gui/src/store/theme.ts
+++ b/gui/src/store/theme.ts
@@ -78,6 +78,11 @@ function getDesignTokens(mode: PaletteMode): ThemeOptions {
           },
         ],
       },
+      MuiToolbar: {
+        defaultProps: {
+          variant: "dense",
+        },
+      },
     },
   };
 }


### PR DESCRIPTION
This change addresses multiple minor issues:

* Changed the settings to use a sidebar instead of tabs.
* Disabled `user-select` globally so the app behaves more like a native app.
* Removed the icon from the sidebar/toolbar on mac because it's not common to see them.
* Fixed the toolbar so it's also present in the sidebar to make sure the window can be dragged when someone clicks on the top of the sidebar.
* Addressed padding inconsistencies between macOS and other systems.
* Fixed the breaking points in the settings and command line buttons.

![Screenshot 2023-08-11 at 12 25 54](https://github.com/iron-wallet/iron/assets/934580/44e8f34d-c4e4-49e0-b368-c64b9fa61fb0)
