### PR TITLE
Dev mode notice and new WS endpoint

### DIFF
--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -11,7 +11,7 @@ use tauri::{
 use tauri::{Menu, Submenu, WindowMenuEvent};
 use tauri_plugin_window_state::{AppHandleExt, Builder as windowStatePlugin, StateFlags};
 
-use crate::error::AppResult;
+use crate::{commands, error::AppResult};
 
 pub struct IronApp {
     app: tauri::App,
@@ -24,6 +24,7 @@ impl IronApp {
         let mut builder = Builder::default()
             .plugin(windowStatePlugin::default().build())
             .invoke_handler(tauri::generate_handler![
+                commands::get_build_mode,
                 iron_settings::commands::settings_get,
                 iron_settings::commands::settings_set,
                 iron_settings::commands::settings_set_dark_mode,

--- a/bin/iron/src/commands.rs
+++ b/bin/iron/src/commands.rs
@@ -1,0 +1,8 @@
+#[tauri::command]
+pub fn get_build_mode() -> String {
+    if cfg!(debug_assertions) {
+        "debug".to_string()
+    } else {
+        "release".to_string()
+    }
+}

--- a/bin/iron/src/main.rs
+++ b/bin/iron/src/main.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod app;
+mod commands;
 mod error;
 
 use error::AppResult;

--- a/crates/ws/src/server.rs
+++ b/crates/ws/src/server.rs
@@ -18,7 +18,7 @@ pub use crate::error::{WsError, WsResult};
 use crate::peers::{Peer, Peers};
 
 pub(crate) async fn server_loop() {
-    let addr = "127.0.0.1:9002";
+    let addr = std::env::var("IRON_SERVER_ENDPOINT").unwrap_or("127.0.0.1:9002".into());
     let listener = TcpListener::bind(&addr).await.expect("Can't listen to");
 
     while let Ok((stream, _)) = listener.accept().await {

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1,10 +1,18 @@
-import { GlobalStyles, ThemeProvider } from "@mui/material";
+import {
+  Box,
+  GlobalStyles,
+  Stack,
+  ThemeProvider,
+  Typography,
+} from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
+import { red } from "@mui/material/colors";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Route, Router, Switch } from "wouter";
 
 import {
   CommandBar,
+  DevBuildNotice,
   HomePage,
   MsgSignDialog,
   TxReviewDialog,
@@ -34,6 +42,7 @@ export default function App() {
       <GlobalStyles styles={globalStyles} />
       <CssBaseline>
         <QueryClientProvider client={queryClient}>
+          <DevBuildNotice />
           <OnboardingWrapper>
             <WagmiWrapper>
               <Routes />

--- a/gui/src/components/DevBuildNotice.tsx
+++ b/gui/src/components/DevBuildNotice.tsx
@@ -1,0 +1,29 @@
+import { Stack, Typography } from "@mui/material";
+import { red } from "@mui/material/colors";
+
+import { useInvoke } from "../hooks";
+
+export function DevBuildNotice() {
+  const { data: buildMode } = useInvoke<string>("get_build_mode");
+
+  if (buildMode === "debug") {
+    return (
+      <Stack
+        alignItems="center"
+        sx={{
+          backgroundColor: red[300],
+          position: "fixed",
+          left: 0,
+          right: 0,
+          top: 0,
+          height: "15px",
+          zIndex: 1000000,
+        }}
+      >
+        <Typography sx={{ fontSize: "10px" }}>dev build</Typography>
+      </Stack>
+    );
+  } else {
+    return null;
+  }
+}

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -26,3 +26,4 @@ export { Txs } from "./Txs";
 export { WagmiWrapper } from "./WagmiWrapper";
 export { WalletUnlockDialog } from "./WalletUnlockDialog";
 export { MsgSignDialog } from "./MsgSignDialog";
+export { DevBuildNotice } from "./DevBuildNotice";


### PR DESCRIPTION
- Making it clear when we're running a debug version or the actual Iron installed on the same system.
- adding the option of setting a different WS endpoint, so that we can have both debug and release versions running simultaneously
![image](https://github.com/iron-wallet/iron/assets/283819/aa419344-d856-4ff2-8c2a-985e78771559)
