### PR TITLE
Removing unused scripting permissions

### DIFF
--- a/extension/src/public/manifest.json
+++ b/extension/src/public/manifest.json
@@ -28,7 +28,7 @@
       "resources": ["/inpage/inpage.js"]
     }
   ],
-  "permissions": ["scripting", "storage"],
+  "permissions": ["storage"],
   "icons": {
     "16": "icons/iron-16.png",
     "48": "icons/iron-48.png",

--- a/extension/src/public/manifestv2.json
+++ b/extension/src/public/manifestv2.json
@@ -29,7 +29,7 @@
       "resources": ["/inpage/inpage.js"]
     }
   ],
-  "permissions": ["scripting", "storage"],
+  "permissions": ["storage"],
   "icons": {
     "16": "icons/iron-16.png",
     "48": "icons/iron-48.png",


### PR DESCRIPTION
We don't use this permission (we inject scripts, but via content-script, which apparently does not require this)
Chrome web store rejected our first submission over it