### PR TITLE
Removes network name from ChainChanged version

### DIFF
--- a/crates/broadcast/src/lib.rs
+++ b/crates/broadcast/src/lib.rs
@@ -8,7 +8,7 @@ use url::Url;
 /// Supported messages
 #[derive(Debug, Clone)]
 pub enum InternalMsg {
-    ChainChanged(u32, String),
+    ChainChanged(u32),
     AccountsChanged(Vec<ChecksummedAddress>),
 
     ResetAnvilListener { chain_id: u32, http: Url, ws: Url },
@@ -48,8 +48,8 @@ mod internal_msgs {
     }
 
     /// Broadcasts `ChainChanged` events
-    pub async fn chain_changed(chain_id: u32, name: String) {
-        send(ChainChanged(chain_id, name)).await;
+    pub async fn chain_changed(chain_id: u32) {
+        send(ChainChanged(chain_id)).await;
     }
 
     /// Broadcasts `AccountsChanged` events

--- a/crates/networks/src/lib.rs
+++ b/crates/networks/src/lib.rs
@@ -125,7 +125,7 @@ impl Networks {
     fn notify_peers(&self) {
         let current = self.get_current_network().clone();
         tokio::spawn(async move {
-            iron_broadcast::chain_changed(current.chain_id, current.name.clone()).await;
+            iron_broadcast::chain_changed(current.chain_id).await;
         });
     }
 

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -147,7 +147,7 @@ impl Handler {
         Ok(json!({
             "isUnlocked": true,
             "chainId": network.chain_id_hex(),
-            "networkVersion": network.name,
+            "networkVersion": network.chain_id.to_string(),
             "accounts": [address],
         }))
     }

--- a/crates/ws/src/init.rs
+++ b/crates/ws/src/init.rs
@@ -32,9 +32,7 @@ async fn receiver() -> ! {
             use InternalMsg::*;
 
             match msg {
-                ChainChanged(chain_id, name) => {
-                    Peers::read().await.broadcast_chain_changed(chain_id, name)
-                }
+                ChainChanged(chain_id) => Peers::read().await.broadcast_chain_changed(chain_id),
                 AccountsChanged(accounts) => {
                     Peers::read().await.broadcast_accounts_changed(accounts)
                 }

--- a/crates/ws/src/peers.rs
+++ b/crates/ws/src/peers.rs
@@ -75,12 +75,12 @@ impl Peers {
     }
 
     /// Broadcasts a `chainChanged` event to all peers
-    pub fn broadcast_chain_changed(&self, chain_id: u32, name: String) {
+    pub fn broadcast_chain_changed(&self, chain_id: u32) {
         self.broadcast(json!({
             "method": "chainChanged",
             "params": {
                 "chainId": format!("0x{:x}", chain_id),
-                "networkVersion": name
+                "networkVersion": chain_id.to_string()
             }
         }));
     }


### PR DESCRIPTION
It turns out the `networkVersion` field is a metamask-specific field that we don't actually need. This trickles down into the even logic, where we were sending the chain name alongside the chain ID in order to feed that field.

We can safely remove it and return the stringified chain ID instead (for backwards compatibility with prior versions of the extension. The field needs to be there, but its value doesn't matter much)