### PR TITLE
fixed extension yarn setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2833,7 +2833,7 @@ dependencies = [
 
 [[package]]
 name = "iron-exchange-rates"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "ethers",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:eslint": "eslint .",
     "lint:tsc": "tsc --noEmit",
     "lint:prettier": "prettier --check .",
-    "setup": "yarn install && yarn extension:build"
+    "setup": "yarn install && yarn ext:build"
   },
   "workspaces": [
     "extension",


### PR DESCRIPTION
this fixes the yarn setup script, which was not working
Cargo.lock was updated when I built the app locally - iron-exchange-rates version updated to 0.5.0 automatically