### PR TITLE
Clean up extension code

### DIFF
--- a/extension/e2e/test.e2e.ts
+++ b/extension/e2e/test.e2e.ts
@@ -1,8 +1,8 @@
-import { $, $$, browser, expect } from "@wdio/globals";
-import type { Capabilities } from "@wdio/types";
+// import { $, $$, browser, expect } from "@wdio/globals";
+// import type { Capabilities } from "@wdio/types";
 
-const isFirefox =
-  (browser.capabilities as Capabilities.Capabilities).browserName === "firefox";
+// const isFirefox =
+//   (browser.capabilities as Capabilities.Capabilities).browserName === "firefox";
 
 describe("Web Extension e2e test", () => {
   // it("should have injected the component from the content script", async () => {

--- a/extension/package.json
+++ b/extension/package.json
@@ -91,7 +91,6 @@
     "json-rpc-middleware-stream": "^4.2.1",
     "loglevel": "^1.8.1",
     "mipd": "^0.0.5",
-    "pump": "^3.0.0",
     "stream": "^0.0.2",
     "webextension-polyfill": "^0.10.0",
     "websocket-stream": "^5.5.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -81,12 +81,11 @@
   "dependencies": {
     "@lukeed/uuid": "^2.0.1",
     "@metamask/eth-json-rpc-middleware": "https://github.com/MetaMask/eth-json-rpc-middleware#e7a1de5cc9c76f24f436be69850d442c46582975",
-    "@metamask/object-multiplex": "^1.2.0",
     "@metamask/post-message-stream": "^6.1.0",
     "eth-json-rpc-filters": "^6.0.0",
     "eth-rpc-errors": "^4.0.3",
+    "eventemitter3": "^5.0.1",
     "extension-port-stream": "^2.1.1",
-    "fast-deep-equal": "^3.1.3",
     "is-stream": "^3.0.0",
     "json-rpc-engine": "^6.1.0",
     "json-rpc-middleware-stream": "^4.2.1",

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -14,8 +14,7 @@ let settings: Settings = defaultSettings;
  * Loads the current settings, and listens for incoming connections (from the injected contentscript)
  */
 export async function init() {
-  settings = (await loadSettings()) as Settings;
-  log.setLevel(settings.logLevel);
+  settings = await loadSettings();
 
   // handle each incoming content script connection
   browser.runtime.onConnect.addListener(async (remotePort: Runtime.Port) => {
@@ -43,7 +42,7 @@ export function setupProviderConnection(port: Runtime.Port) {
 
   // pre-build the websocket connection
   // not actually buit until the first message arrives
-  const wsBuilder = new WebsocketBuilder(ironBackendEndpoint(port))
+  const wsBuilder = new WebsocketBuilder(endpoint(port))
     .withBackoff(new ConstantBackoff(1000))
     .onOpen((instance, event) => {
       // connection is ready. set the upper `ws` value, and flush the backlog
@@ -78,8 +77,8 @@ export function setupProviderConnection(port: Runtime.Port) {
 /**
  * The URL of the Iron server if given from the settings, with connection metadata being appended as URL params
  */
-function ironBackendEndpoint(port: Runtime.Port) {
-  return `${settings.endpoint}?${connectionParams(port)}`;
+function endpoint(port: Runtime.Port) {
+  return `${settings.endpoint}?${connParams(port)}`;
 }
 
 /**
@@ -87,7 +86,7 @@ function ironBackendEndpoint(port: Runtime.Port) {
  *
  * This includes all info that may be useful for the Iron server.
  */
-function connectionParams(port: Runtime.Port) {
+function connParams(port: Runtime.Port) {
   const sender = port.sender;
   const tab = sender?.tab;
 

--- a/extension/src/content-script/index.ts
+++ b/extension/src/content-script/index.ts
@@ -1,10 +1,9 @@
 import PortStream from "extension-port-stream";
 import log from "loglevel";
-import pump, { type Stream } from "pump";
+import pump from "pump";
 import { type Duplex } from "stream";
 import { runtime } from "webextension-polyfill";
 
-import ObjectMultiplex from "@metamask/object-multiplex";
 import { WindowPostMessageStream } from "@metamask/post-message-stream";
 
 import { loadSettings } from "../settings";
@@ -28,48 +27,12 @@ export function initProviderForward() {
     target: "iron:provider:inpage",
   }) as unknown as Duplex;
 
-  const inpageMux = new ObjectMultiplex();
-  (inpageMux as unknown as Duplex).setMaxListeners(25);
-  pump(
-    inpageMux as unknown as Stream,
-    inpageStream,
-    inpageMux as unknown as Stream,
-    (err) => warnDisconnect("Iron Inpage Multiplex", err)
-  );
-
-  const pageChannel = inpageMux.createStream(
-    "iron-provider"
-  ) as unknown as Duplex;
-
   // bg stream
   const bgPort = runtime.connect({ name: "iron:contentscript" });
   const bgStream = new PortStream(bgPort);
 
-  // create and connect channel muxers
-  // so we can handle the channels individually
-  const bgMux = new ObjectMultiplex();
-  (bgMux as unknown as Duplex).setMaxListeners(25);
-  bgMux.ignoreStream("publicConfig"); // TODO:LegacyProvider: Delete
-
-  pump(
-    bgMux as unknown as Stream,
-    bgStream,
-    bgMux as unknown as Stream,
-    (err?: Error) => {
-      warnDisconnect("Iron Background Multiplex", err);
-    }
-  );
-
-  const extensionChannel = bgMux.createStream("iron-provider");
-  pump(
-    pageChannel,
-    extensionChannel as unknown as Stream,
-    pageChannel,
-    (error?: Error) =>
-      log.debug(
-        `Iron: Muxed traffic for channel "iron:provider" failed.`,
-        error
-      )
+  pump(inpageStream, bgStream, inpageStream, (error?: Error) =>
+    log.debug(`Iron: Muxed traffic for channel "iron:provider" failed.`, error)
   );
 }
 
@@ -92,11 +55,4 @@ export function injectInPageScript() {
   } catch (error) {
     log.error("Iron Wallet: Provider injection failed.", error);
   }
-}
-
-/**
- * Logs a warning if the stream disconnects
- */
-function warnDisconnect(remoteLabel: string, error?: Error) {
-  log.debug(`[iron] Content script lost connection "${remoteLabel}".`, error);
 }

--- a/extension/src/content-script/index.ts
+++ b/extension/src/content-script/index.ts
@@ -1,6 +1,5 @@
 import PortStream from "extension-port-stream";
 import log from "loglevel";
-import pump from "pump";
 import { type Duplex } from "stream";
 import { runtime } from "webextension-polyfill";
 
@@ -23,17 +22,15 @@ async function init() {
  */
 export function initProviderForward() {
   const inpageStream = new WindowPostMessageStream({
-    name: "iron:provider:contentscript",
-    target: "iron:provider:inpage",
+    name: "iron:contentscript",
+    target: "iron:inpage",
   }) as unknown as Duplex;
 
   // bg stream
   const bgPort = runtime.connect({ name: "iron:contentscript" });
   const bgStream = new PortStream(bgPort);
 
-  pump(inpageStream, bgStream, inpageStream, (error?: Error) =>
-    log.debug(`Iron: Muxed traffic for channel "iron:provider" failed.`, error)
-  );
+  inpageStream.pipe(bgStream).pipe(inpageStream);
 }
 
 /**

--- a/extension/src/inpage/index.ts
+++ b/extension/src/inpage/index.ts
@@ -28,8 +28,8 @@ export function init() {
  */
 export function initializeProvider() {
   const connectionStream = new WindowPostMessageStream({
-    name: "iron:provider:inpage",
-    target: "iron:provider:contentscript",
+    name: "iron:inpage",
+    target: "iron:contentscript",
   }) as unknown as Duplex;
 
   const provider = new IronProvider(connectionStream);

--- a/extension/src/inpage/provider.ts
+++ b/extension/src/inpage/provider.ts
@@ -1,63 +1,28 @@
-import { EthereumRpcError, ethErrors } from "eth-rpc-errors";
-import dequal from "fast-deep-equal";
+import { EthereumRpcError } from "eth-rpc-errors";
+import { EventEmitter } from "eventemitter3";
 import { isDuplexStream } from "is-stream";
 import { JsonRpcEngine, createIdRemapMiddleware } from "json-rpc-engine";
 import { createStreamMiddleware } from "json-rpc-middleware-stream";
 import log from "loglevel";
 import pump from "pump";
-import type { Duplex } from "stream";
+import { type Duplex } from "stream";
 
-import ObjectMultiplex from "@metamask/object-multiplex";
-import SafeEventEmitter from "@metamask/safe-event-emitter";
-
-import {
-  Address,
-  ProviderState,
-  Request,
-  RequestArguments,
-  SingleOrBatchRequest,
-} from "./types";
+import { Address, RequestArguments } from "./types";
 import { Maybe, createErrorMiddleware, getRpcPromiseCallback } from "./utils";
 
-export class IronProvider extends SafeEventEmitter {
-  /**
-   * Indicating that this provider is an Iron provider.
-   */
-  public readonly isIron: boolean = true;
-
-  protected state: {
-    chainId?: string;
-    accounts: Address[];
-    isConnected: boolean;
-    initialized: boolean;
-    isPermanentlyDisconnected: boolean;
-    engineSetupFinished: boolean;
-  };
-
+export class IronProvider extends EventEmitter {
+  protected initialized: boolean = false;
   protected autoId = 0;
   protected engine: JsonRpcEngine;
-
-  /**
-   * Connection creation is lazy.
-   * So we need to hold the given connectionStream until we are actually ready to connect
-   */
-  protected pendingConnectionStream?: Duplex;
+  protected stream: Duplex;
 
   /**
    * @param connectionStream - A Node.js duplex stream
    */
-  constructor(connectionStream: Duplex) {
+  constructor(stream: Duplex) {
     super();
-    this.bindFunctions();
-    this.pendingConnectionStream = connectionStream;
-    this.setMaxListeners(100);
-    this.state = this.defaultState();
+    this.stream = stream;
     this.engine = new JsonRpcEngine();
-  }
-
-  // Returns whether the provider can process RPC requests.
-  public isConnected(): boolean {
-    return this.state.isConnected;
   }
 
   /**
@@ -70,66 +35,19 @@ export class IronProvider extends SafeEventEmitter {
    * @returns A Promise that resolves with the result of the RPC method,
    * or rejects if an error is encountered.
    */
-  public async request<T>(args: RequestArguments): Promise<Maybe<T>> {
-    // initialization calls `metamask_getProviderState`,
-    // so we need to explicitly skip this call to avoid infinite recursion
-    if (args.method !== "metamask_getProviderState") {
-      await this.initialize();
-    }
-
-    if (!args || typeof args !== "object" || Array.isArray(args)) {
-      throw ethErrors.rpc.invalidRequest({
-        message: "Expected a single, non-array, object argument",
-        data: args,
-      });
-    }
-
-    const { method, params } = args;
-
-    if (typeof method !== "string" || method.length === 0) {
-      throw ethErrors.rpc.invalidRequest({
-        message: `'args.method' must be a non-empty string.`,
-        data: args,
-      });
-    }
-
-    if (
-      params !== undefined &&
-      !Array.isArray(params) &&
-      (typeof params !== "object" || params === null)
-    ) {
-      throw ethErrors.rpc.invalidRequest({
-        message: `'args.params' must be an object or array if provided.`,
-        data: args,
-      });
-    }
+  public async request<T>({
+    method,
+    params,
+  }: RequestArguments): Promise<Maybe<T>> {
+    await this.initialize();
 
     return new Promise<T>((resolve, reject) => {
-      this.rpcRequest(
-        { method, params },
+      this.engine.handle(
+        { method, params, id: this.nextId(), jsonrpc: "2.0" },
+        // { method, params, id, jsonrpc: "2.0" },
         getRpcPromiseCallback(resolve as any, reject) as any
       );
     });
-  }
-
-  /**
-   * Internal RPC method. Forwards requests to background via the RPC engine.
-   * Also remap ids inbound and outbound.
-   *
-   * @param payload - The RPC request object.
-   * @param callback - The consumer's callback.
-   */
-  protected rpcRequest(
-    payload: SingleOrBatchRequest,
-    cb: (...args: unknown[]) => void
-  ) {
-    if (!Array.isArray(payload)) {
-      const request = this.sanitizeRequest(payload);
-      return this.engine.handle(request, cb);
-    } else {
-      const request = payload.map(this.sanitizeRequest);
-      return this.engine.handle(request, cb);
-    }
   }
 
   /**
@@ -140,11 +58,7 @@ export class IronProvider extends SafeEventEmitter {
    * @emits IronProvider#connect
    */
   protected handleConnect(chainId: string) {
-    if (!this.state.isConnected) {
-      this.state.isConnected = true;
-      this.emit("connect", { chainId });
-      log.debug(`Iron: Connected to chain with ID "${chainId}".`);
-    }
+    this.emit("connect", { chainId });
   }
 
   /**
@@ -158,21 +72,13 @@ export class IronProvider extends SafeEventEmitter {
    * @emits BaseProvider#disconnect
    */
   protected handleDisconnect(errorMessage: string) {
-    if (this.state.isConnected || !this.state.isPermanentlyDisconnected) {
-      this.state.isConnected = false;
+    const error = new EthereumRpcError(
+      1011, // Internal error
+      errorMessage
+    );
 
-      const error = new EthereumRpcError(
-        1011, // Internal error
-        errorMessage
-      );
-
-      log.error(error);
-      this.state.chainId = undefined;
-      this.state.accounts = [];
-      this.state.isPermanentlyDisconnected = true;
-
-      this.emit("disconnect", error);
-    }
+    log.error(error);
+    this.emit("disconnect", error);
   }
 
   /**
@@ -187,13 +93,7 @@ export class IronProvider extends SafeEventEmitter {
     log.info("handleChainChanged", { chainId });
 
     this.handleConnect(chainId);
-
-    if (chainId !== this.state.chainId) {
-      this.state.chainId = chainId;
-      if (this.state.initialized) {
-        this.emit("chainChanged", chainId);
-      }
-    }
+    this.emit("chainChanged", chainId);
   }
 
   /**
@@ -207,120 +107,27 @@ export class IronProvider extends SafeEventEmitter {
    */
   protected handleAccountsChanged(accounts: Address[]): void {
     log.info("handleAccountsChanged", accounts);
-
-    // emit accountsChanged if anything about the accounts array has changed
-    if (!dequal(this.state.accounts, accounts)) {
-      this.state.accounts = accounts;
-
-      // finally, after all state has been updated, emit the event
-      if (this.state.initialized) {
-        this.emit("accountsChanged", accounts);
-      }
-    }
+    this.emit("accountsChanged", accounts);
   }
 
-  /**
-   * Calls `metamask_getProviderState` and sets initial state
-   * if provided and marks this provider as initialized.
-   * Throws if called more than once.
-   */
   protected async initialize() {
-    if (this.state.initialized) {
+    if (this?.initialized) {
       return;
     }
-
-    this.setupEngine();
-
-    try {
-      const initialState = await this.request<ProviderState>({
-        method: "metamask_getProviderState",
-      });
-
-      if (this.state.initialized) {
-        throw new Error("Provider already initialized.");
-      }
-
-      if (initialState) {
-        const { accounts, chainId } = initialState;
-
-        // EIP-1193 connect
-        this.handleConnect(chainId);
-        this.handleChainChanged({ chainId });
-        this.handleAccountsChanged(accounts);
-      }
-
-      this.state.initialized = true;
-      this.emit("_initialized");
-    } catch (error) {
-      log.error(
-        "Iron: Failed to get initial state. Please report this bug.",
-        error
-      );
-    }
-  }
-
-  /**
-   * Called when connection is lost to critical streams. Emits an 'error' event
-   * from the provider with the error message and stack if present.
-   *
-   * @emits BaseProvider#disconnect
-   */
-  private handleStreamDisconnect(streamName: string, error?: Error) {
-    let warningMsg = `Iron: Lost connection to "${streamName}".`;
-    if (error?.stack) {
-      warningMsg += `\n${error.stack}`;
-    }
-
-    log.warn(warningMsg);
-    if (this.listenerCount("error") > 0) {
-      this.emit("error", warningMsg);
-    }
-
-    this.handleDisconnect(
-      error
-        ? error.message
-        : "Iron: Disconnected from Iron background. Page reload required."
-    );
-  }
-
-  /* Bind functions to prevent consumers from making unbound calls */
-  private bindFunctions() {
-    this.handleAccountsChanged = this.handleAccountsChanged.bind(this);
-    this.handleConnect = this.handleConnect.bind(this);
-    this.handleChainChanged = this.handleChainChanged.bind(this);
-    this.handleDisconnect = this.handleDisconnect.bind(this);
-    this.rpcRequest = this.rpcRequest.bind(this);
-    this.request = this.request.bind(this);
-    this.handleStreamDisconnect = this.handleStreamDisconnect.bind(this);
-  }
-
-  private setupEngine() {
-    if (!this.pendingConnectionStream) {
-      return;
-    }
+    this.initialized = true;
 
     const connection = createStreamMiddleware();
-    const stream = this.pendingConnectionStream;
 
-    if (!isDuplexStream(stream)) {
+    if (!isDuplexStream(this.stream)) {
       throw new Error("IronProvider - Invalid Duplex Stream");
     }
 
     this.engine.push(createIdRemapMiddleware());
     this.engine.push(createErrorMiddleware());
 
-    // Set up connectionStream multiplexing
-    const mux = new ObjectMultiplex();
-    pump(stream, mux as unknown as Duplex, stream, (e) =>
-      this.handleStreamDisconnect("Iron constructor", e)
-    );
-
     // Set up RPC connection
-    pump(
-      connection.stream,
-      mux.createStream("iron-provider") as unknown as Duplex,
-      connection.stream,
-      (e) => this.handleStreamDisconnect("Iron RpcProvider", e)
+    pump(connection.stream, this.stream, connection.stream, (e) =>
+      this.handleStreamDisconnect(e)
     );
 
     // Wire up the JsonRpcEngine to the JSON-RPC connection stream
@@ -338,7 +145,7 @@ export class IronProvider extends SafeEventEmitter {
           break;
 
         case "METAMASK_STREAM_FAILURE":
-          stream.destroy(
+          this.stream.destroy(
             new Error(
               "Iron: Disconnected from Iron background. Page reload required."
             )
@@ -358,32 +165,34 @@ export class IronProvider extends SafeEventEmitter {
           }
       }
     });
-    this.pendingConnectionStream = undefined;
   }
 
-  private sanitizeRequest(req: Request) {
-    return {
-      id: req.id || this.nextId(),
-      jsonrpc: req.jsonrpc || "2.0",
-      method: req.method,
-      params: req.params,
-    };
+  /**
+   * Called when connection is lost to critical streams. Emits an 'error' event
+   * from the provider with the error message and stack if present.
+   *
+   * @emits BaseProvider#disconnect
+   */
+  private handleStreamDisconnect(error?: Error) {
+    let warningMsg = `Iron: Connection lost`;
+    if (error?.stack) {
+      warningMsg += `\n${error.stack}`;
+    }
+
+    log.warn(warningMsg);
+    if (this.listenerCount("error") > 0) {
+      this.emit("error", warningMsg);
+    }
+
+    this.handleDisconnect(
+      error
+        ? error.message
+        : "Iron: Disconnected from Iron background. Page reload required."
+    );
   }
 
   private nextId() {
     this.autoId++;
     return `auto-${this.autoId}`;
-  }
-
-  private defaultState() {
-    return {
-      chainId: undefined,
-      accounts: [],
-      isConnected: false,
-      isUnlocked: false,
-      initialized: false,
-      isPermanentlyDisconnected: false,
-      engineSetupFinished: false,
-    };
   }
 }

--- a/extension/src/inpage/provider.ts
+++ b/extension/src/inpage/provider.ts
@@ -10,7 +10,7 @@ import { Address, RequestArguments } from "./types";
 import { Maybe, createErrorMiddleware, getRpcPromiseCallback } from "./utils";
 
 export class IronProvider extends EventEmitter {
-  protected initialized: boolean = false;
+  protected initialized = false;
   protected autoId = 0;
   protected engine: JsonRpcEngine;
   protected stream: Duplex;

--- a/extension/src/inpage/types.ts
+++ b/extension/src/inpage/types.ts
@@ -1,25 +1,8 @@
-import type { JsonRpcId, JsonRpcVersion } from "json-rpc-engine";
-
-export type SingleOrBatchRequest = Request | Request[];
-
-export interface Request {
-  id?: JsonRpcId;
-  jsonrpc?: JsonRpcVersion;
-  method: string;
-  params?: unknown;
-}
-
 export interface RequestArguments {
   /* The RPC method to request. */
   method: string;
   /* The params of the RPC method, if any. */
   params?: unknown[] | Record<string, unknown>;
-}
-
-export interface ProviderState {
-  accounts: Address[];
-  chainId: string;
-  isUnlocked: boolean;
 }
 
 export type Address = `0x${string}`;

--- a/extension/src/inpage/types.ts
+++ b/extension/src/inpage/types.ts
@@ -1,8 +1,6 @@
 export interface RequestArguments {
-  /* The RPC method to request. */
   method: string;
-  /* The params of the RPC method, if any. */
-  params?: unknown[] | Record<string, unknown>;
+  params?: unknown;
 }
 
 export type Address = `0x${string}`;

--- a/gui/src/components/QuickAddressSelect.tsx
+++ b/gui/src/components/QuickAddressSelect.tsx
@@ -61,7 +61,7 @@ function getCurrentPath(wallet: Wallet, addresses: [string, Address][]) {
       return wallet.current ? wallet.current[0] : addresses[0][0];
 
     case "impersonator":
-      return wallet.addresses[wallet.current!];
+      return wallet.addresses[wallet.current || 0];
 
     default:
       return wallet.currentPath || addresses[0][0];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1728,15 +1728,6 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
-"@metamask/object-multiplex@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/object-multiplex/-/object-multiplex-1.2.0.tgz#38fc15c142f61939391e1b9a8eed679696c7e4f4"
-  integrity sha512-hksV602d3NWE2Q30Mf2Np1WfVKaGqfJRy9vpHAmelbaD0OkDt06/0KQkRR6UVYdMbTbkuEu8xN5JDUU80inGwQ==
-  dependencies:
-    end-of-stream "^1.4.4"
-    once "^1.4.0"
-    readable-stream "^2.3.3"
-
 "@metamask/post-message-stream@^6.1.0":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@metamask/post-message-stream/-/post-message-stream-6.1.1.tgz#d0995eac40206bdb5727c94c8b1fb2f4e1d037f8"
@@ -6118,7 +6109,7 @@ encode-utf8@^1.0.3:
   resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
   integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1, end-of-stream@^1.4.4, end-of-stream@~1.4.1:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1, end-of-stream@~1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -6891,6 +6882,11 @@ eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
 events@^3.0.0, events@^3.1.0, events@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
* Simplifies connection logic to remove packages such as `pump` and `object-multiplexer`, which were metamask leftovers we don't actually need
* Removes all internal state of the provider (other than `initialized` check), to simplify it even further