### PR TITLE
Fixes extension provider not working on eip6963.org

### DIFF
--- a/extension/src/inpage/provider.ts
+++ b/extension/src/inpage/provider.ts
@@ -20,8 +20,19 @@ export class IronProvider extends EventEmitter {
    */
   constructor(stream: Duplex) {
     super();
+    this.bindFunctions();
     this.stream = stream;
     this.engine = new JsonRpcEngine();
+  }
+
+  private bindFunctions() {
+    this.request = this.request.bind(this);
+    this.handleConnect = this.handleConnect.bind(this);
+    this.handleDisconnect = this.handleDisconnect.bind(this);
+    this.handleChainChanged = this.handleChainChanged.bind(this);
+    this.handleAccountsChanged = this.handleAccountsChanged.bind(this);
+    this.initialize = this.initialize.bind(this);
+    this.nextId = this.nextId.bind(this);
   }
 
   /**


### PR DESCRIPTION
I mistakenly removed these `bind`s, but they're needed.
To reproduce: the previous version couldn't connect to eip6963.org