### PR TITLE
Fixes crash on wrong password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ dependencies = [
  "rust-argon2",
  "serde",
  "serde_json",
+ "thiserror",
  "zeroize",
 ]
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -12,6 +12,7 @@ authors.workspace = true
 ethers = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
 anyhow = "1.0.71"
 chacha20poly1305 = "0.10.1"
 rust-argon2 = "1.0.0"

--- a/crates/crypto/src/error.rs
+++ b/crates/crypto/src/error.rs
@@ -1,0 +1,10 @@
+#[derive(Debug, thiserror::Error)]
+pub enum CryptoError {
+    #[error("Invalid password")]
+    InvalidPassword,
+
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+pub type CryptoResult<T> = std::result::Result<T, CryptoError>;


### PR DESCRIPTION
Fixes a rust crash when the unlock password was incorrect.
The correct behaviour is for an `Err` to be returned to update the UI, but instead there was an `unwrap()` somewhere in there