### PR TITLE
Add iron-http crate with initial Axum setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.9",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2820,6 +2869,7 @@ dependencies = [
  "iron-dialogs",
  "iron-exchange-rates",
  "iron-forge",
+ "iron-http",
  "iron-networks",
  "iron-rpc",
  "iron-settings",
@@ -2950,6 +3000,16 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "iron-http"
+version = "0.6.1"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -3532,6 +3592,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "matchit"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "maybe-uninit"
@@ -5210,6 +5276,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa 1.0.9",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5755,6 +5831,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sys-locale"
@@ -6374,6 +6456,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6386,6 +6490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/networks",
   "crates/wallets",
   "crates/ws",
+  "crates/http",
   "crates/rpc",
   "crates/connections",
   "crates/dialogs",
@@ -39,6 +40,7 @@ iron-settings = { path = "crates/settings" }
 iron-networks = { path = "crates/networks" }
 iron-wallets = { path = "crates/wallets" }
 iron-ws = { path = "crates/ws" }
+iron-http = { path = "crates/http" }
 iron-rpc = { path = "crates/rpc" }
 iron-connections = { path = "crates/connections" }
 iron-dialogs = { path = "crates/dialogs" }

--- a/bin/iron/Cargo.toml
+++ b/bin/iron/Cargo.toml
@@ -16,6 +16,7 @@ iron-wallets = { workspace = true }
 iron-dialogs = { workspace = true }
 iron-rpc = { workspace = true }
 iron-ws = { workspace = true }
+iron-http = { workspace = true }
 iron-connections = { workspace = true }
 iron-types = { workspace = true }
 iron-db = { workspace = true }

--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -101,6 +101,7 @@ async fn init(app: &tauri::App) -> AppResult<()> {
     iron_sync::init(db).await;
     iron_settings::init(resource(app, "settings.json")).await;
     iron_ws::init().await;
+    iron_http::init().await;
     iron_connections::init(resource(app, "connections.json")).await;
     iron_wallets::init(resource(app, "wallets.json")).await;
     iron_networks::init(resource(app, "networks.json")).await;

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "iron-http"
+version.workspace = true
+edition.workspace = true
+license-file.workspace = true
+homepage.workspace = true
+repository.workspace = true
+exclude.workspace = true
+authors.workspace = true
+
+[dependencies]
+axum = "0.6"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }

--- a/crates/http/src/init.rs
+++ b/crates/http/src/init.rs
@@ -1,0 +1,17 @@
+use axum::{response::Html, routing::get, Router};
+
+pub async fn init() {
+    tokio::spawn(async {
+        let routes = Router::new().route("/", get(Html("Hello world!")));
+
+        let addr = std::env::var("IRON_HTTP_SERVER_ENDPOINT")
+            .unwrap_or("127.0.0.1:9003".into())
+            .parse()
+            .unwrap();
+
+        axum::Server::bind(&addr)
+            .serve(routes.into_make_service())
+            .await
+            .unwrap();
+    });
+}

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,0 +1,3 @@
+mod init;
+
+pub use init::init;

--- a/crates/ws/src/server.rs
+++ b/crates/ws/src/server.rs
@@ -17,7 +17,7 @@ pub use crate::error::{WsError, WsResult};
 use crate::peers::{Peer, Peers};
 
 pub(crate) async fn server_loop() {
-    let addr = std::env::var("IRON_SERVER_ENDPOINT").unwrap_or("127.0.0.1:9002".into());
+    let addr = std::env::var("IRON_WS_SERVER_ENDPOINT").unwrap_or("127.0.0.1:9002".into());
     let listener = TcpListener::bind(&addr).await.expect("Can't listen to");
 
     while let Ok((stream, _)) = listener.accept().await {


### PR DESCRIPTION
Why:
* Starting the migration proposed in issue #371

How:
* Creating a new crate in `crates/http` that spawns an Axum server.
  The server for now only responds to the `/` endpoint with a "Hello
  world!" message. The server runs by default at `127.0.0.1:9003` but
  can be configured through an env var `IRON_HTTP_SERVER_ENDPOINT`
* Adding the new crate to `Cargo.toml`
* Calling the `init` function from the `iron-http` crate in
  `bin/iron/src/app.rs`
