### PR TITLE
Correctly respond to JSON-RPC requests on `iron-http`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,8 +3013,10 @@ name = "iron-http"
 version = "0.6.2"
 dependencies = [
  "axum",
+ "iron-rpc",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
 ]
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -9,7 +9,11 @@ exclude.workspace = true
 authors.workspace = true
 
 [dependencies]
-axum = "0.6"
+iron-rpc = { workspace = true }
+
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
+thiserror = { workspace = true }
+
+axum = "0.6"

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -20,8 +20,9 @@ impl serde::Serialize for Error {
     }
 }
 
+// TODO: revisit this to correctly respond with the appropriate status code
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        (StatusCode::INTERNAL_SERVER_ERROR, "UNHANDLED_CLIENT_ERROR").into_response()
+        (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()).into_response()
     }
 }

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -1,0 +1,27 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("serialization error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl serde::Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_ref())
+    }
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        (StatusCode::INTERNAL_SERVER_ERROR, "UNHANDLED_CLIENT_ERROR").into_response()
+    }
+}

--- a/crates/http/src/init.rs
+++ b/crates/http/src/init.rs
@@ -6,7 +6,7 @@ use crate::error::Result;
 
 pub async fn init() {
     tokio::spawn(async {
-        let routes = Router::new().merge(routes_rpc());
+        let routes = Router::new().merge(rpc_proxy());
 
         let addr = std::env::var("IRON_HTTP_SERVER_ENDPOINT")
             .unwrap_or("127.0.0.1:9003".into())
@@ -20,8 +20,8 @@ pub async fn init() {
     });
 }
 
-fn routes_rpc() -> Router {
-    Router::new().route("/", post(handler_rpc))
+fn rpc_proxy() -> Router {
+    Router::new().route("/", post(rpc_handler))
 }
 
 #[derive(Debug, Deserialize)]
@@ -29,7 +29,7 @@ struct RpcParams {
     domain: Option<String>,
 }
 
-async fn handler_rpc(Query(params): Query<RpcParams>, payload: String) -> Result<Json<Value>> {
+async fn rpc_handler(Query(params): Query<RpcParams>, payload: String) -> Result<Json<Value>> {
     let domain = params.domain;
     let handler = iron_rpc::Handler::new(domain);
 

--- a/crates/http/src/init.rs
+++ b/crates/http/src/init.rs
@@ -1,8 +1,12 @@
-use axum::{response::Html, routing::get, Router};
+use axum::{extract::Query, routing::post, Json, Router};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::error::Result;
 
 pub async fn init() {
     tokio::spawn(async {
-        let routes = Router::new().route("/", get(Html("Hello world!")));
+        let routes = Router::new().merge(routes_rpc());
 
         let addr = std::env::var("IRON_HTTP_SERVER_ENDPOINT")
             .unwrap_or("127.0.0.1:9003".into())
@@ -14,4 +18,23 @@ pub async fn init() {
             .await
             .unwrap();
     });
+}
+
+fn routes_rpc() -> Router {
+    Router::new().route("/", post(handler_rpc))
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcParams {
+    domain: Option<String>,
+}
+
+async fn handler_rpc(Query(params): Query<RpcParams>, payload: String) -> Result<Json<Value>> {
+    let domain = params.domain;
+    let handler = iron_rpc::Handler::new(domain.clone());
+
+    let reply = handler.handle(payload).await;
+    let reply = reply.unwrap_or_else(|| serde_json::Value::Null.to_string());
+
+    Ok(Json(serde_json::from_str(&reply)?))
 }

--- a/crates/http/src/init.rs
+++ b/crates/http/src/init.rs
@@ -31,7 +31,7 @@ struct RpcParams {
 
 async fn handler_rpc(Query(params): Query<RpcParams>, payload: String) -> Result<Json<Value>> {
     let domain = params.domain;
-    let handler = iron_rpc::Handler::new(domain.clone());
+    let handler = iron_rpc::Handler::new(domain);
 
     let reply = handler.handle(payload).await;
     let reply = reply.unwrap_or_else(|| serde_json::Value::Null.to_string());

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,3 +1,4 @@
+mod error;
 mod init;
 
 pub use init::init;


### PR DESCRIPTION
Why:
* Continuing the migration proposed in issue #371

How:
* Adding a `handler_rpc` function that handles JSON-RPC requests made to `/`,
  using `iron_rpc::Handler`
* Replacing the temporary implementation of the router in `http/init.rs` to make use
  of the new handler function
* Adding an `error.rs` with error type declarations
* Making the needed changes to `lib.rs` and `Cargo.toml`

With this change, it's now possible to use Iron as a JSON-RPC provider, via HTTP:

```js
import { ethers } from "ethers";

const provider = new ethers.JsonRpcProvider("http://127.0.0.1:9003");

console.log(await provider.getBlockNumber());
```
