### PR TITLE
Fixing nested btn error

### DIFF
--- a/gui/src/components/AddressView.tsx
+++ b/gui/src/components/AddressView.tsx
@@ -44,12 +44,7 @@ export function AddressView({ contextMenu, address, copyIcon }: Props) {
   const content = (
     <>
       {alias ? alias : truncateEthAddress(address)}
-
-      {copyIcon && (
-        <IconButton>
-          <ContentCopySharp fontSize="small" />
-        </IconButton>
-      )}
+      {copyIcon && <ContentCopySharp fontSize="small" sx={{ ml: 1 }} />}
     </>
   );
 


### PR DESCRIPTION
The markup on AddressView was wrong, and including a button nested inside another button