### PR TITLE
Including `value` for payable functions in Contract interface

### DIFF
--- a/gui/src/components/ABIForm.tsx
+++ b/gui/src/components/ABIForm.tsx
@@ -96,11 +96,8 @@ function ABIItemForm({ contract, item }: { contract: Address; item: ABIItem }) {
         setCallResult(JSON.stringify(result));
       }
     } else {
-      const value =
-        item.stateMutability === "payable" && params.value ? params.value : "";
-
       const result = await invoke<string>("rpc_send_transaction", {
-        params: { to: contract, value, data },
+        params: { to: contract, value: params.value, data },
       });
       setTxResult(result);
     }

--- a/gui/src/components/ABIForm.tsx
+++ b/gui/src/components/ABIForm.tsx
@@ -96,7 +96,8 @@ function ABIItemForm({ contract, item }: { contract: Address; item: ABIItem }) {
         setCallResult(JSON.stringify(result));
       }
     } else {
-      const value = item.stateMutability === "payable" && params.value ? params.value : "";
+      const value =
+        item.stateMutability === "payable" && params.value ? params.value : "";
 
       const result = await invoke<string>("rpc_send_transaction", {
         params: { to: contract, value, data },

--- a/gui/src/components/ABIForm.tsx
+++ b/gui/src/components/ABIForm.tsx
@@ -96,8 +96,10 @@ function ABIItemForm({ contract, item }: { contract: Address; item: ABIItem }) {
         setCallResult(JSON.stringify(result));
       }
     } else {
+      const value = item.stateMutability === "payable" && params.value ? params.value : "";
+
       const result = await invoke<string>("rpc_send_transaction", {
-        params: { to: contract, data },
+        params: { to: contract, value, data },
       });
       setTxResult(result);
     }


### PR DESCRIPTION
Why:
* Solves #405

How:
* Including a `value` key in the params for `rpc_send_transaction` that
  contains the `params.value` value or defaults to empty string
