### PR TITLE
Fast mode

### DIFF
--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -23,6 +23,7 @@ impl IronApp {
                 iron_settings::commands::settings_get,
                 iron_settings::commands::settings_set,
                 iron_settings::commands::settings_set_dark_mode,
+                iron_settings::commands::settings_set_fast_mode,
                 iron_settings::commands::settings_finish_onboarding,
                 iron_settings::commands::settings_set_alias,
                 iron_settings::commands::settings_get_alias,

--- a/crates/rpc/src/send_transaction.rs
+++ b/crates/rpc/src/send_transaction.rs
@@ -8,6 +8,8 @@ use ethers::{
 };
 use iron_dialogs::{Dialog, DialogMsg};
 use iron_networks::Network;
+use iron_settings::Settings;
+use iron_types::GlobalState;
 use iron_wallets::{Wallet, WalletControl};
 
 use super::{Error, Result};
@@ -45,8 +47,8 @@ impl<'a> SendTransaction<'a> {
     pub async fn finish(&mut self) -> Result<PendingTransaction<'_, Http>> {
         tracing::debug!("finishing transaction");
 
-        let skip_dialog = self.network.is_dev() && self.wallet.is_dev();
-        if !skip_dialog {
+        // skip the dialog if both network & wallet allow for it, and if fast_mode is enabled
+        if !(self.network.is_dev() && self.wallet.is_dev() && Settings::read().await.fast_mode()) {
             self.spawn_dialog().await?;
         }
         self.send().await

--- a/crates/settings/src/commands.rs
+++ b/crates/settings/src/commands.rs
@@ -18,6 +18,11 @@ pub async fn settings_set_dark_mode(mode: DarkMode) -> Result<()> {
 }
 
 #[tauri::command]
+pub async fn settings_set_fast_mode(mode: bool) -> Result<()> {
+    Settings::write().await.set_fast_mode(mode).await
+}
+
+#[tauri::command]
 pub async fn settings_finish_onboarding() -> Result<()> {
     Settings::write().await.finish_onboarding().await
 }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -49,6 +49,13 @@ impl Settings {
         Ok(())
     }
 
+    pub async fn set_fast_mode(&mut self, mode: bool) -> Result<()> {
+        self.inner.fast_mode = mode;
+        self.save().await?;
+
+        Ok(())
+    }
+
     pub async fn finish_onboarding(&mut self) -> Result<()> {
         self.inner.onboarded = true;
         self.save().await?;
@@ -113,6 +120,9 @@ pub struct SerializedSettings {
 
     #[serde(default)]
     onboarded: bool,
+
+    #[serde(default)]
+    fast_mode: bool,
 }
 
 impl Default for SerializedSettings {
@@ -126,6 +136,7 @@ impl Default for SerializedSettings {
             hide_empty_tokens: true,
             aliases: HashMap::new(),
             onboarded: false,
+            fast_mode: false,
         }
     }
 }

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -67,6 +67,10 @@ impl Settings {
         &self.inner
     }
 
+    pub fn fast_mode(&self) -> bool {
+        self.inner.fast_mode
+    }
+
     pub fn get_etherscan_api_key(&self) -> Result<String> {
         self.inner
             .etherscan_api_key

--- a/crates/wallets/src/plaintext.rs
+++ b/crates/wallets/src/plaintext.rs
@@ -17,7 +17,6 @@ pub struct PlaintextWallet {
     name: String,
     mnemonic: String,
     derivation_path: String,
-    dev: bool,
     count: u32,
     current_path: String,
 }
@@ -78,7 +77,7 @@ impl WalletControl for PlaintextWallet {
     }
 
     fn is_dev(&self) -> bool {
-        self.dev
+        true
     }
 }
 
@@ -92,7 +91,6 @@ impl Default for PlaintextWallet {
             name: "test".into(),
             mnemonic,
             derivation_path,
-            dev: true,
             count: 3,
             current_path,
         }
@@ -105,7 +103,6 @@ struct Deserializer {
     name: String,
     mnemonic: String,
     derivation_path: String,
-    dev: bool,
     count: u32,
     current_path: Option<String>,
 }
@@ -131,7 +128,6 @@ impl TryFrom<Deserializer> for PlaintextWallet {
             name: value.name,
             mnemonic: value.mnemonic,
             derivation_path: value.derivation_path,
-            dev: value.dev,
             count: value.count,
             current_path: current_path.derivation_string(),
         })

--- a/gui/src/components/CommandBar.tsx
+++ b/gui/src/components/CommandBar.tsx
@@ -23,7 +23,12 @@ import {
 } from "kbar";
 import React, { forwardRef, ReactNode } from "react";
 
-import { useNetworks, useSettingsWindow, useWallets } from "../store";
+import {
+  useNetworks,
+  useSettings,
+  useSettingsWindow,
+  useWallets,
+} from "../store";
 import { useTheme } from "../store/theme";
 
 export function CommandBar({ children }: { children: ReactNode }) {
@@ -70,12 +75,14 @@ function RenderResults() {
 function CommandBarInner() {
   const walletActions = useWallets((s) => s.actions);
   const networkActions = useNetworks((s) => s.actions);
+  const settingsActions = useSettings((s) => s.actions);
   const [theme, themeActions] = useTheme((s) => [s.theme, s.actions]);
   const settingsWindowActions = useSettingsWindow((s) => s.actions);
 
   useRegisterActions(walletActions, [walletActions]);
   useRegisterActions(networkActions, [networkActions]);
-  useRegisterActions(themeActions, [settingsWindowActions]);
+  useRegisterActions(settingsActions, [settingsActions]);
+  useRegisterActions(themeActions, [themeActions]);
   useRegisterActions(settingsWindowActions, [settingsWindowActions]);
 
   return (

--- a/gui/src/components/QuickFastModeToggle.tsx
+++ b/gui/src/components/QuickFastModeToggle.tsx
@@ -1,0 +1,20 @@
+import { FormControlLabel, Switch } from "@mui/material";
+import { invoke } from "@tauri-apps/api/tauri";
+
+import { useSettings } from "@/store";
+
+export function QuickFastModeToggle() {
+  const fastMode = useSettings((s) => s.settings?.fastMode);
+
+  const onChange = (data: React.ChangeEvent<HTMLInputElement>) => {
+    invoke("settings_set_fast_mode", { mode: data.target.checked });
+  };
+
+  return (
+    <FormControlLabel
+      sx={{ pointerEvents: "auto" }}
+      label="Fast mode"
+      control={<Switch checked={fastMode} onChange={onChange} />}
+    />
+  );
+}

--- a/gui/src/components/Settings/General.tsx
+++ b/gui/src/components/Settings/General.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Button,
-  Checkbox,
   FormControl,
   FormControlLabel,
   FormGroup,
@@ -10,6 +9,7 @@ import {
   MenuItem,
   Select,
   Stack,
+  Switch,
   TextField,
 } from "@mui/material";
 import { invoke } from "@tauri-apps/api/tauri";
@@ -75,6 +75,28 @@ export function SettingsGeneral() {
             )}
           />
         </FormControl>
+
+        <FormControl error={!!errors.fastMode}>
+          <FormGroup>
+            <Controller
+              name="fastMode"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  sx={{ pointerEvents: "auto" }}
+                  label="Fast mode"
+                  control={<Switch {...field} checked={field.value} />}
+                />
+              )}
+            />
+          </FormGroup>
+          {errors.abiWatch && (
+            <FormHelperText>
+              {errors.abiWatch.message?.toString()}
+            </FormHelperText>
+          )}
+        </FormControl>
+
         <FormControl error={!!errors.abiWatch}>
           <FormGroup>
             <Controller
@@ -83,7 +105,7 @@ export function SettingsGeneral() {
               render={({ field }) => (
                 <FormControlLabel
                   label="ABI Watcher"
-                  control={<Checkbox {...field} checked={field.value} />}
+                  control={<Switch {...field} checked={field.value} />}
                 />
               )}
             />
@@ -125,7 +147,7 @@ export function SettingsGeneral() {
               render={({ field }) => (
                 <FormControlLabel
                   label="Hide Tokens Without Balance"
-                  control={<Checkbox {...field} checked={field.value} />}
+                  control={<Switch {...field} checked={field.value} />}
                 />
               )}
             />

--- a/gui/src/components/Settings/Wallet/Plaintext.tsx
+++ b/gui/src/components/Settings/Wallet/Plaintext.tsx
@@ -1,12 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Button,
-  Checkbox,
   FormControl,
   FormControlLabel,
   FormGroup,
   FormHelperText,
   Stack,
+  Switch,
   TextField,
 } from "@mui/material";
 import { Controller, FieldValues, useForm } from "react-hook-form";
@@ -61,7 +61,7 @@ export function Plaintext({ wallet, onSubmit, onRemove }: Props) {
                   control={control}
                   render={({ field }) => {
                     return (
-                      <Checkbox
+                      <Switch
                         {...field}
                         checked={field.value}
                         onChange={(e) => field.onChange(e.target.checked)}

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Contracts,
   Logo,
   QuickAddressSelect,
+  QuickFastModeToggle,
   QuickNetworkSelect,
   QuickWalletSelect,
   SettingsButton,
@@ -179,6 +180,7 @@ export function Sidebar() {
             <QuickWalletSelect />
             <QuickAddressSelect />
             <QuickNetworkSelect />
+            <QuickFastModeToggle />
           </Stack>
           <Stack
             p={3}

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -20,6 +20,7 @@ export { Navbar } from "./Navbar";
 export { NestedRoutes } from "./NestedRoutes";
 export { Panel } from "./Panel";
 export { QuickAddressSelect } from "./QuickAddressSelect";
+export { QuickFastModeToggle } from "./QuickFastModeToggle";
 export { QuickNetworkSelect } from "./QuickNetworkSelect";
 export { QuickWalletSelect } from "./QuickWalletSelect";
 export { Settings } from "./Settings/";

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -133,7 +133,6 @@ export const jsonKeystoreSchema = z.object({
 export const plaintextSchema = z.object({
   type: z.literal("plaintext"),
   name: z.string().min(1),
-  dev: z.boolean().default(false),
   mnemonic: mnemonicSchema,
   derivationPath: derivationPathSchema,
   count: z.number().int().min(1),

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -10,6 +10,7 @@ export const generalSettingsSchema = z.object({
   etherscanApiKey: z.string().optional().nullable(),
   hideEmptyTokens: z.boolean(),
   onboarded: z.boolean(),
+  fastMode: z.boolean(),
 });
 
 // const formSchema = schema.shape.network;


### PR DESCRIPTION
This is a useful thing to have ahead of transaction simulation.
So far, it was not really interesting to see transaction popups when using dev accounts + anvil, since there was barely any useful info to work with

Since simulations will be handled via the same popup, it's now useful to have the ability to quickly switch these popups on/off

This will now be done by a global "Fast mode" setting, instead of a "dev wallet" setting on plaintext wallets.
The idea is that plaintext wallets are always developer-friendly, and anything else isn't (since it will require a password prompt anyway, so fast mode is never an option).

In the new behaviour, when using a dev node, a dev wallet, *and* fast mode is enabled, dialogs will be skipped.

A toggle switch was also added to the sidebar, and command bar, to easily toggle this

![image](https://github.com/iron-wallet/iron/assets/283819/0e5dce4b-c12c-4fef-b95d-947912078515)
