### PR TITLE
Fix TX simulation bug

### DIFF
--- a/gui/src/components/AddressView.tsx
+++ b/gui/src/components/AddressView.tsx
@@ -37,7 +37,7 @@ export function AddressView({ contextMenu, address, copyIcon }: Props) {
 
   const content = (
     <>
-      {alias ? alias : truncateEthAddress(address)}
+      {alias ? alias : truncateEthAddress(`${address}`)}
       {copyIcon && <ContentCopySharp fontSize="small" sx={{ ml: 1 }} />}
     </>
   );


### PR DESCRIPTION
Why:
* Doing a transaction was causing the TX simulation window to not open
  properly

How:
* Interpolating the address passed to the `truncateEthAddress` function
  to prevent JS to assume the address as an hexstring and not a string

Co-Authored-By: Resende <17102689+ZePedroResende@users.noreply.github.com>
