### PR TITLE
Implement the `/iron/forge/name` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,6 +3752,7 @@ dependencies = [
  "iron-forge",
  "iron-rpc",
  "iron-types",
+ "iron-ws",
  "serde",
  "serde_json",
  "thiserror",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -9,9 +9,10 @@ exclude.workspace = true
 authors.workspace = true
 
 [dependencies]
-iron-rpc = { workspace = true }
 iron-forge = { workspace = true }
+iron-rpc = { workspace = true }
 iron-types = { workspace = true }
+iron-ws = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/http/src/routes/forge.rs
+++ b/crates/http/src/routes/forge.rs
@@ -5,15 +5,21 @@ use serde::Deserialize;
 use crate::Result;
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct ForgeGetAbiParams {
+pub(crate) struct ForgeParams {
     address: Address,
     chain_id: u32,
 }
 
 pub(crate) async fn get_abi_handler(
-    Query(params): Query<ForgeGetAbiParams>,
+    Query(params): Query<ForgeParams>,
 ) -> Result<Json<Option<Abi>>> {
     Ok(Json(
         iron_forge::commands::forge_get_abi(params.address, params.chain_id).await?,
+    ))
+}
+
+pub(crate) async fn get_name_handler(Query(params): Query<ForgeParams>) -> Result<Json<Option<String>>> {
+    Ok(Json(
+        iron_forge::commands::forge_get_name(params.address, params.chain_id).await?,
     ))
 }

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -5,6 +5,7 @@ use axum::{
 
 mod forge;
 mod rpc;
+mod ws;
 
 pub(crate) fn router() -> Router {
     let rpc = Router::new().route("/", post(rpc::handler));
@@ -14,5 +15,12 @@ pub(crate) fn router() -> Router {
         Router::new().route("/abi", get(forge::get_abi_handler)),
     );
 
-    Router::new().merge(rpc).nest("/iron", forge)
+    let ws = Router::new().nest(
+        "/ws",
+        Router::new().route("/peers_by_domain", get(ws::get_peers_by_domain_handler)),
+    );
+
+    let iron = Router::new().merge(forge).merge(ws);
+
+    Router::new().merge(rpc).nest("/iron", iron)
 }

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -12,7 +12,9 @@ pub(crate) fn router() -> Router {
 
     let forge = Router::new().nest(
         "/forge",
-        Router::new().route("/abi", get(forge::get_abi_handler)),
+        Router::new()
+            .route("/abi", get(forge::get_abi_handler))
+            .route("/name", get(forge::get_name_handler)),
     );
 
     let ws = Router::new().nest(

--- a/crates/http/src/routes/ws.rs
+++ b/crates/http/src/routes/ws.rs
@@ -1,0 +1,10 @@
+use axum::Json;
+use serde_json::Value;
+
+use crate::Result;
+
+pub(crate) async fn get_peers_by_domain_handler() -> Result<Json<Value>> {
+    Ok(Json(serde_json::to_value(
+        &(iron_ws::commands::ws_peers_by_domain().await),
+    )?))
+}

--- a/crates/http/src/routes/ws.rs
+++ b/crates/http/src/routes/ws.rs
@@ -1,10 +1,10 @@
+use std::collections::HashMap;
+
 use axum::Json;
-use serde_json::Value;
+use iron_ws::peers::Peer;
 
 use crate::Result;
 
-pub(crate) async fn get_peers_by_domain_handler() -> Result<Json<Value>> {
-    Ok(Json(serde_json::to_value(
-        &(iron_ws::commands::ws_peers_by_domain().await),
-    )?))
+pub(crate) async fn get_peers_by_domain_handler() -> Result<Json<HashMap<String, Vec<Peer>>>> {
+    Ok(Json(iron_ws::commands::ws_peers_by_domain().await))
 }

--- a/crates/ws/src/lib.rs
+++ b/crates/ws/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod commands;
 mod error;
 mod init;
-mod peers;
+pub mod peers;
 mod server;
 
 pub use error::{WsError, WsResult};


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue move from IPC to HTTP #371

How:
* Adding a new endpoint for the newly added `forge_get_name` command
* Renaming the `ForgeGetAbiParams` struct to `ForgeParams` in order to
  be usable by both endpoints
