### PR TITLE
Implement the `iron/connections` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,6 +3749,7 @@ name = "iron-http"
 version = "0.6.2"
 dependencies = [
  "axum",
+ "iron-connections",
  "iron-forge",
  "iron-rpc",
  "iron-types",

--- a/crates/connections/src/commands.rs
+++ b/crates/connections/src/commands.rs
@@ -4,8 +4,8 @@ use iron_types::{Affinity, GlobalState};
 use crate::{Result, Store};
 
 #[tauri::command]
-pub async fn connections_affinity_for(domain: String) -> Result<Affinity> {
-    Ok(Store::read().await.get_affinity(&domain))
+pub async fn connections_affinity_for(domain: String) -> Affinity {
+    Store::read().await.get_affinity(&domain)
 }
 
 #[tauri::command]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -9,6 +9,7 @@ exclude.workspace = true
 authors.workspace = true
 
 [dependencies]
+iron-connections = { workspace = true }
 iron-forge = { workspace = true }
 iron-rpc = { workspace = true }
 iron-types = { workspace = true }

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -10,6 +10,15 @@ pub enum Error {
 
     #[error(transparent)]
     Forge(#[from] iron_forge::Error),
+
+    #[error(transparent)]
+    IO(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Connection(#[from] iron_connections::Error),
+
+    #[error("invalid chain id: {0}")]
+    InvalidChainId(u32),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/http/src/routes/connections.rs
+++ b/crates/http/src/routes/connections.rs
@@ -1,0 +1,30 @@
+use axum::{extract::Query, Json};
+use iron_types::Affinity;
+use serde::Deserialize;
+
+use crate::Result;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GetConnectionParams {
+    domain: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetConnectionParams {
+    domain: String,
+    affinity: Affinity,
+}
+
+pub(crate) async fn get_connections_affinity_for_handler(
+    Query(params): Query<GetConnectionParams>,
+) -> Json<Affinity> {
+    Json(iron_connections::commands::connections_affinity_for(params.domain).await)
+}
+
+pub(crate) async fn set_connections_affinity_for_handler(
+    Json(payload): Json<SetConnectionParams>,
+) -> Result<()> {
+    iron_connections::commands::connections_set_affinity(&payload.domain, payload.affinity).await?;
+
+    Ok(())
+}

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -3,6 +3,7 @@ use axum::{
     Router,
 };
 
+mod connections;
 mod forge;
 mod rpc;
 mod ws;
@@ -15,12 +16,25 @@ pub(crate) fn router() -> Router {
         Router::new().route("/abi", get(forge::get_abi_handler)),
     );
 
+    let connections = Router::new().nest(
+        "/connections",
+        Router::new()
+            .route(
+                "/affinity_for",
+                get(connections::get_connections_affinity_for_handler),
+            )
+            .route(
+                "/affinity_for",
+                post(connections::set_connections_affinity_for_handler),
+            ),
+    );
+
     let ws = Router::new().nest(
         "/ws",
         Router::new().route("/peers_by_domain", get(ws::get_peers_by_domain_handler)),
     );
 
-    let iron = Router::new().merge(forge).merge(ws);
+    let iron = Router::new().merge(forge).merge(ws).merge(connections);
 
     Router::new().merge(rpc).nest("/iron", iron)
 }


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Adding GET and POST `/iron/connections/affinity_for` handlers
* Updating the `iron-http` router to include the new endpoints