### PR TITLE
Implement `/iron/networks/` endpoints

### DIFF
--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
     #[error(transparent)]
     Connection(#[from] iron_connections::Error),
 
+    #[error(transparent)]
+    Network(#[from] iron_networks::Error),
+
     #[error("invalid chain id: {0}")]
     InvalidChainId(u32),
 

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -5,6 +5,7 @@ use crate::Ctx;
 mod connections;
 mod contracts;
 mod forge;
+mod networks;
 mod rpc;
 mod ws;
 
@@ -16,6 +17,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/connections", connections::router())
                 .nest("/contracts", contracts::router())
+                .nest("/networks", networks::router())
                 .nest("/ws", ws::router()),
         )
         .nest("/", rpc::router())

--- a/crates/http/src/routes/networks.rs
+++ b/crates/http/src/routes/networks.rs
@@ -1,0 +1,53 @@
+use axum::{
+    extract::Query,
+    routing::{get, post},
+    Json, Router,
+};
+use iron_networks::Network;
+use serde::Deserialize;
+
+use crate::{Ctx, Result};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetNetworkParams {
+    network: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SetNetworkListParams {
+    new_networks: Vec<Network>,
+}
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/current", get(current))
+        .route("/current", post(set_current))
+        .route("/list", get(list))
+        .route("/list", post(set_list))
+        .route("/reset", post(reset))
+}
+
+pub(crate) async fn current() -> Result<Json<Network>> {
+    Ok(Json(iron_networks::commands::networks_get_current().await?))
+}
+
+pub(crate) async fn set_current(Query(params): Query<SetNetworkParams>) -> Result<()> {
+    iron_networks::commands::networks_set_current(params.network).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn list() -> Result<Json<Vec<Network>>> {
+    Ok(Json(iron_networks::commands::networks_get_list().await?))
+}
+
+pub(crate) async fn set_list(Json(payload): Json<SetNetworkListParams>) -> Result<()> {
+    iron_networks::commands::networks_set_list(payload.new_networks).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn reset() -> Result<Json<Vec<Network>>> {
+    Ok(Json(iron_networks::commands::networks_reset().await?))
+}


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Implementing endpoints for the `iron-networks` commands
* Updating the `iron-http` router to include the `/networks` routes
