### PR TITLE
Implement `/iron/settings/` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,6 +3761,7 @@ dependencies = [
  "iron-networks",
  "iron-rpc",
  "iron-settings",
+ "iron-simulator",
  "iron-types",
  "iron-wallets",
  "iron-ws",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,6 +3760,7 @@ dependencies = [
  "iron-forge",
  "iron-networks",
  "iron-rpc",
+ "iron-settings",
  "iron-types",
  "iron-ws",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "iron-rpc",
  "iron-settings",
  "iron-types",
+ "iron-wallets",
  "iron-ws",
  "serde",
  "serde_json",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -15,6 +15,7 @@ iron-forge = { workspace = true }
 iron-networks = { workspace = true }
 iron-rpc = { workspace = true }
 iron-settings = { workspace = true }
+iron-simulator = { workspace = true }
 iron-types = { workspace = true }
 iron-wallets = { workspace = true }
 iron-ws = { workspace = true }

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -14,6 +14,7 @@ iron-db = { workspace = true }
 iron-forge = { workspace = true }
 iron-networks = { workspace = true }
 iron-rpc = { workspace = true }
+iron-settings = { workspace = true }
 iron-types = { workspace = true }
 iron-ws = { workspace = true }
 

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -16,6 +16,7 @@ iron-networks = { workspace = true }
 iron-rpc = { workspace = true }
 iron-settings = { workspace = true }
 iron-types = { workspace = true }
+iron-wallets = { workspace = true }
 iron-ws = { workspace = true }
 
 serde = { workspace = true }

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -20,6 +20,9 @@ pub enum Error {
     #[error(transparent)]
     Network(#[from] iron_networks::Error),
 
+    #[error(transparent)]
+    Settings(#[from] iron_settings::Error),
+
     #[error("invalid chain id: {0}")]
     InvalidChainId(u32),
 

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     Settings(#[from] iron_settings::Error),
 
     #[error(transparent)]
+    Simulation(#[from] iron_simulator::errors::SimulationError),
+
+    #[error(transparent)]
     Wallets(#[from] iron_wallets::Error),
 
     #[error("invalid chain id: {0}")]

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[error(transparent)]
     Settings(#[from] iron_settings::Error),
 
+    #[error(transparent)]
+    Wallets(#[from] iron_wallets::Error),
+
     #[error("invalid chain id: {0}")]
     InvalidChainId(u32),
 

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -17,6 +17,9 @@ pub enum Error {
     #[error(transparent)]
     Connection(#[from] iron_connections::Error),
 
+    #[error(transparent)]
+    Network(#[from] iron_networks::Error),
+
     #[error("invalid chain id: {0}")]
     InvalidChainId(u32),
 

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -7,6 +7,7 @@ mod contracts;
 mod forge;
 mod networks;
 mod rpc;
+mod settings;
 mod ws;
 
 pub(crate) fn router() -> Router<Ctx> {
@@ -14,10 +15,11 @@ pub(crate) fn router() -> Router<Ctx> {
         .nest(
             "/iron",
             Router::new()
-                .nest("/forge", forge::router())
                 .nest("/connections", connections::router())
                 .nest("/contracts", contracts::router())
+                .nest("/forge", forge::router())
                 .nest("/networks", networks::router())
+                .nest("/settings", settings::router())
                 .nest("/ws", ws::router()),
         )
         .nest("/", rpc::router())

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -8,6 +8,7 @@ mod forge;
 mod networks;
 mod rpc;
 mod settings;
+mod wallets;
 mod ws;
 
 pub(crate) fn router() -> Router<Ctx> {
@@ -20,6 +21,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/networks", networks::router())
                 .nest("/settings", settings::router())
+                .nest("/wallets", wallets::router())
                 .nest("/ws", ws::router()),
         )
         .nest("/", rpc::router())

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -8,6 +8,7 @@ mod forge;
 mod networks;
 mod rpc;
 mod settings;
+mod simulator;
 mod wallets;
 mod ws;
 
@@ -21,6 +22,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/networks", networks::router())
                 .nest("/settings", settings::router())
+                .nest("/simulator", simulator::router())
                 .nest("/wallets", wallets::router())
                 .nest("/ws", ws::router()),
         )

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -5,6 +5,7 @@ use crate::Ctx;
 mod connections;
 mod contracts;
 mod forge;
+mod networks;
 mod rpc;
 mod ws;
 
@@ -16,6 +17,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/connections", connections::router())
                 .nest("/contracts", contracts::router())
+                .nest("/networks", networks::router())
                 .nest("/ws", ws::router()),
         )
         .nest("/", rpc::router())

--- a/crates/http/src/routes/networks.rs
+++ b/crates/http/src/routes/networks.rs
@@ -1,0 +1,53 @@
+use axum::{
+    extract::Query,
+    routing::{get, post},
+    Json, Router,
+};
+use iron_networks::Network;
+use serde::Deserialize;
+
+use crate::{Ctx, Result};
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetNetworkParams {
+    network: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SetNetworkListParams {
+    new_networks: Vec<Network>,
+}
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/current", get(current))
+        .route("/current", post(set_current))
+        .route("/list", get(list))
+        .route("/list", post(set_list))
+        .route("/reset", post(reset))
+}
+
+pub(crate) async fn current() -> Result<Json<Network>> {
+    Ok(Json(iron_networks::commands::networks_get_current().await?))
+}
+
+pub(crate) async fn set_current(Query(params): Query<SetNetworkParams>) -> Result<()> {
+    iron_networks::commands::networks_set_current(params.network).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn list() -> Result<Json<Vec<Network>>> {
+    Ok(Json(iron_networks::commands::networks_get_list().await?))
+}
+
+pub(crate) async fn set_list(Json(payload): Json<SetNetworkListParams>) -> Result<()> {
+    iron_networks::commands::networks_set_list(payload.new_networks).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn reset() -> Result<Json<Vec<Network>>> {
+    Ok(Json(iron_networks::commands::networks_reset().await?))
+}

--- a/crates/http/src/routes/settings.rs
+++ b/crates/http/src/routes/settings.rs
@@ -1,0 +1,86 @@
+use axum::{
+    extract::Query,
+    routing::{get, post},
+    Json, Router,
+};
+use iron_settings::{DarkMode, SerializedSettings};
+use iron_types::ChecksummedAddress;
+use serde::Deserialize;
+
+use crate::{Ctx, Result};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SetSettings {
+    new_settings: SerializedSettings,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct DarkModeParams {
+    mode: DarkMode,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct FastModeParams {
+    mode: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GetAliasParams {
+    address: ChecksummedAddress,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetAliasParams {
+    address: ChecksummedAddress,
+    alias: Option<String>,
+}
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/", get(settings))
+        .route("/", post(set_settings))
+        .route("/set_dark_mode", post(set_dark_mode))
+        .route("/set_fast_mode", post(set_fast_mode))
+        .route("/finish_onboarding", post(finish_onboarding))
+        .route("/alias", get(alias))
+        .route("/alias", post(set_alias))
+}
+
+pub(crate) async fn settings() -> Json<SerializedSettings> {
+    Json(iron_settings::commands::settings_get().await)
+}
+
+pub(crate) async fn set_settings(Json(payload): Json<SetSettings>) -> Result<()> {
+    iron_settings::commands::settings_set(payload.new_settings).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn set_dark_mode(Query(params): Query<DarkModeParams>) -> Result<()> {
+    iron_settings::commands::settings_set_dark_mode(params.mode).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn set_fast_mode(Query(params): Query<FastModeParams>) -> Result<()> {
+    iron_settings::commands::settings_set_fast_mode(params.mode).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn finish_onboarding() -> Result<()> {
+    iron_settings::commands::settings_finish_onboarding().await?;
+
+    Ok(())
+}
+
+pub(crate) async fn alias(Query(params): Query<GetAliasParams>) -> Json<Option<String>> {
+    Json(iron_settings::commands::settings_get_alias(params.address).await)
+}
+
+pub(crate) async fn set_alias(Query(params): Query<SetAliasParams>) -> Result<()> {
+    iron_settings::commands::settings_set_alias(params.address, params.alias).await;
+
+    Ok(())
+}

--- a/crates/http/src/routes/simulator.rs
+++ b/crates/http/src/routes/simulator.rs
@@ -1,0 +1,24 @@
+use axum::{routing::get, Json, Router};
+
+use iron_simulator::{errors::SimulationResult, types::Result, Request};
+use serde::Deserialize;
+
+use crate::{Ctx, Result as HttpResult};
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new().route("/run", get(run))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SimulationPayload {
+    chain_id: u32,
+    request: Request,
+}
+
+pub(crate) async fn run(
+    Json(SimulationPayload { chain_id, request }): Json<SimulationPayload>,
+) -> HttpResult<Json<SimulationResult<Result>>> {
+    Ok(Json(
+        iron_simulator::commands::simulator_run(chain_id, request).await,
+    ))
+}

--- a/crates/http/src/routes/wallets.rs
+++ b/crates/http/src/routes/wallets.rs
@@ -1,0 +1,126 @@
+use axum::{
+    extract::{Path, Query},
+    routing::{delete, get, post, put},
+    Json, Router,
+};
+use iron_types::ChecksummedAddress;
+use iron_wallets::Wallet;
+use serde::Deserialize;
+
+use crate::{Ctx, Result};
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/all", get(all))
+        .route("/current_wallet", get(current_wallet))
+        .route("/current_address", get(current_address))
+        .route("/wallet", post(create))
+        .route("/wallet/:name", put(update))
+        .route("/wallet/:name", delete(remove))
+        .route("/current_wallet", post(set_current_wallet))
+        .route("/current_path", post(set_current_path))
+        .route("/wallet_addresses", get(get_wallet_addresses))
+        .route("/mnemonic_addresses", get(get_mnemonic_addresses))
+        .route("/validate_mnemonic", get(validate_mnemonic))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetCurrentWalletPayload {
+    idx: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetCurrentPathPayload {
+    key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GetWalletAddressParams {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MnemonicAddressesPayload {
+    mnemonic: String,
+    derivation_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ValidateMnemonicPayload {
+    mnemonic: String,
+}
+
+pub(crate) async fn all() -> Json<Vec<Wallet>> {
+    Json(iron_wallets::commands::wallets_get_all().await)
+}
+
+pub(crate) async fn current_wallet() -> Result<Json<Wallet>> {
+    Ok(Json(iron_wallets::commands::wallets_get_current().await?))
+}
+
+pub(crate) async fn current_address() -> Result<Json<ChecksummedAddress>> {
+    Ok(Json(
+        iron_wallets::commands::wallets_get_current_address().await?,
+    ))
+}
+
+pub(crate) async fn create(Json(payload): Json<iron_types::Json>) -> Result<()> {
+    iron_wallets::commands::wallets_create(payload).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn update(
+    Path(name): Path<String>,
+    Json(payload): Json<iron_types::Json>,
+) -> Result<()> {
+    iron_wallets::commands::wallets_update(name, payload).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn remove(Path(name): Path<String>) -> Result<()> {
+    iron_wallets::commands::wallets_remove(name).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn set_current_wallet(
+    Json(SetCurrentWalletPayload { idx }): Json<SetCurrentWalletPayload>,
+) -> Result<()> {
+    iron_wallets::commands::wallets_set_current_wallet(idx).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn set_current_path(
+    Json(SetCurrentPathPayload { key }): Json<SetCurrentPathPayload>,
+) -> Result<()> {
+    iron_wallets::commands::wallets_set_current_path(key).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn get_wallet_addresses(
+    Query(GetWalletAddressParams { name }): Query<GetWalletAddressParams>,
+) -> Result<Json<Vec<(String, ChecksummedAddress)>>> {
+    Ok(Json(
+        iron_wallets::commands::wallets_get_wallet_addresses(name).await?,
+    ))
+}
+
+pub(crate) async fn get_mnemonic_addresses(
+    Json(MnemonicAddressesPayload {
+        mnemonic,
+        derivation_path,
+    }): Json<MnemonicAddressesPayload>,
+) -> Json<Vec<(String, ChecksummedAddress)>> {
+    Json(iron_wallets::commands::wallets_get_mnemonic_addresses(mnemonic, derivation_path).await)
+}
+
+pub(crate) async fn validate_mnemonic(
+    Json(ValidateMnemonicPayload { mnemonic }): Json<ValidateMnemonicPayload>,
+) -> Json<bool> {
+    Json(iron_wallets::commands::wallets_validate_mnemonic(mnemonic))
+}

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod commands;
-mod errors;
+pub mod errors;
 pub mod evm;
-mod types;
+pub mod types;
 
 pub use evm::Evm;
 pub use types::{Request, Result};


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Implementing endpoints for the `iron-settings` commands
* Updating the `iron-http` router to include the `/settings` routes
