### PR TITLE
Implement `/iron/wallets/` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3762,6 +3762,7 @@ dependencies = [
  "iron-rpc",
  "iron-settings",
  "iron-types",
+ "iron-wallets",
  "iron-ws",
  "serde",
  "serde_json",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -16,6 +16,7 @@ iron-networks = { workspace = true }
 iron-rpc = { workspace = true }
 iron-settings = { workspace = true }
 iron-types = { workspace = true }
+iron-wallets = { workspace = true }
 iron-ws = { workspace = true }
 
 serde = { workspace = true }

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
     #[error(transparent)]
     Settings(#[from] iron_settings::Error),
 
+    #[error(transparent)]
+    Wallets(#[from] iron_wallets::Error),
+
     #[error("invalid chain id: {0}")]
     InvalidChainId(u32),
 

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -8,6 +8,7 @@ mod forge;
 mod networks;
 mod rpc;
 mod settings;
+mod wallets;
 mod ws;
 
 pub(crate) fn router() -> Router<Ctx> {
@@ -20,6 +21,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/networks", networks::router())
                 .nest("/settings", settings::router())
+                .nest("/wallets", wallets::router())
                 .nest("/ws", ws::router()),
         )
         .nest("/", rpc::router())

--- a/crates/http/src/routes/wallets.rs
+++ b/crates/http/src/routes/wallets.rs
@@ -1,0 +1,126 @@
+use axum::{
+    extract::{Path, Query},
+    routing::{delete, get, post, put},
+    Json, Router,
+};
+use iron_types::ChecksummedAddress;
+use iron_wallets::Wallet;
+use serde::Deserialize;
+
+use crate::{Ctx, Result};
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/all", get(all))
+        .route("/current_wallet", get(current_wallet))
+        .route("/current_address", get(current_address))
+        .route("/wallet", post(create))
+        .route("/wallet/:name", put(update))
+        .route("/wallet/:name", delete(remove))
+        .route("/current_wallet", post(set_current_wallet))
+        .route("/current_path", post(set_current_path))
+        .route("/wallet_addresses", get(get_wallet_addresses))
+        .route("/mnemonic_addresses", get(get_mnemonic_addresses))
+        .route("/validate_mnemonic", get(validate_mnemonic))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetCurrentWalletPayload {
+    idx: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct SetCurrentPathPayload {
+    key: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GetWalletAddressParams {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MnemonicAddressesPayload {
+    mnemonic: String,
+    derivation_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ValidateMnemonicPayload {
+    mnemonic: String,
+}
+
+pub(crate) async fn all() -> Json<Vec<Wallet>> {
+    Json(iron_wallets::commands::wallets_get_all().await)
+}
+
+pub(crate) async fn current_wallet() -> Result<Json<Wallet>> {
+    Ok(Json(iron_wallets::commands::wallets_get_current().await?))
+}
+
+pub(crate) async fn current_address() -> Result<Json<ChecksummedAddress>> {
+    Ok(Json(
+        iron_wallets::commands::wallets_get_current_address().await?,
+    ))
+}
+
+pub(crate) async fn create(Json(payload): Json<iron_types::Json>) -> Result<()> {
+    iron_wallets::commands::wallets_create(payload).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn update(
+    Path(name): Path<String>,
+    Json(payload): Json<iron_types::Json>,
+) -> Result<()> {
+    iron_wallets::commands::wallets_update(name, payload).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn remove(Path(name): Path<String>) -> Result<()> {
+    iron_wallets::commands::wallets_remove(name).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn set_current_wallet(
+    Json(SetCurrentWalletPayload { idx }): Json<SetCurrentWalletPayload>,
+) -> Result<()> {
+    iron_wallets::commands::wallets_set_current_wallet(idx).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn set_current_path(
+    Json(SetCurrentPathPayload { key }): Json<SetCurrentPathPayload>,
+) -> Result<()> {
+    iron_wallets::commands::wallets_set_current_path(key).await?;
+
+    Ok(())
+}
+
+pub(crate) async fn get_wallet_addresses(
+    Query(GetWalletAddressParams { name }): Query<GetWalletAddressParams>,
+) -> Result<Json<Vec<(String, ChecksummedAddress)>>> {
+    Ok(Json(
+        iron_wallets::commands::wallets_get_wallet_addresses(name).await?,
+    ))
+}
+
+pub(crate) async fn get_mnemonic_addresses(
+    Json(MnemonicAddressesPayload {
+        mnemonic,
+        derivation_path,
+    }): Json<MnemonicAddressesPayload>,
+) -> Json<Vec<(String, ChecksummedAddress)>> {
+    Json(iron_wallets::commands::wallets_get_mnemonic_addresses(mnemonic, derivation_path).await)
+}
+
+pub(crate) async fn validate_mnemonic(
+    Json(ValidateMnemonicPayload { mnemonic }): Json<ValidateMnemonicPayload>,
+) -> Json<bool> {
+    Json(iron_wallets::commands::wallets_validate_mnemonic(mnemonic))
+}


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Implementing endpoints for the `iron-wallets` commands
* Updating the `iron-http` router to include the `/wallets` routes
