### PR TITLE
Implement `/iron/db/` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3782,6 +3782,8 @@ name = "iron-http"
 version = "0.6.2"
 dependencies = [
  "axum",
+ "ethers",
+ "iron-broadcast",
  "iron-connections",
  "iron-db",
  "iron-forge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,6 +3791,7 @@ dependencies = [
  "iron-rpc",
  "iron-settings",
  "iron-simulator",
+ "iron-sync-alchemy",
  "iron-types",
  "iron-wallets",
  "iron-ws",

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -2,7 +2,7 @@ pub mod commands;
 mod error;
 mod pagination;
 mod queries;
-mod utils;
+pub mod utils;
 
 use std::{path::PathBuf, str::FromStr};
 
@@ -199,7 +199,7 @@ impl DB {
         Ok(res)
     }
 
-    async fn get_transactions(
+    pub async fn get_transactions(
         &self,
         chain_id: u32,
         from_or_to: Address,

--- a/crates/db/src/utils.rs
+++ b/crates/db/src/utils.rs
@@ -8,7 +8,7 @@ use iron_types::GlobalState;
 
 use crate::Result;
 
-pub(crate) async fn fetch_etherscan_contract_name(
+pub async fn fetch_etherscan_contract_name(
     chain: Chain,
     address: Address,
 ) -> Result<Option<String>> {
@@ -23,7 +23,7 @@ pub(crate) async fn fetch_etherscan_contract_name(
     }
 }
 
-pub(crate) async fn fetch_etherscan_abi(chain: Chain, address: Address) -> Result<Option<Abi>> {
+pub async fn fetch_etherscan_abi(chain: Chain, address: Address) -> Result<Option<Abi>> {
     let api_key = Settings::read().await.get_etherscan_api_key()?;
 
     let client = Client::new(chain, api_key)?;

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -9,6 +9,7 @@ exclude.workspace = true
 authors.workspace = true
 
 [dependencies]
+iron-broadcast = { workspace = true }
 iron-connections = { workspace = true }
 iron-db = { workspace = true }
 iron-forge = { workspace = true }
@@ -20,6 +21,7 @@ iron-types = { workspace = true }
 iron-wallets = { workspace = true }
 iron-ws = { workspace = true }
 
+ethers = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -17,6 +17,7 @@ iron-networks = { workspace = true }
 iron-rpc = { workspace = true }
 iron-settings = { workspace = true }
 iron-simulator = { workspace = true }
+iron-sync-alchemy = { workspace = true }
 iron-types = { workspace = true }
 iron-wallets = { workspace = true }
 iron-ws = { workspace = true }

--- a/crates/http/src/routes/db.rs
+++ b/crates/http/src/routes/db.rs
@@ -1,0 +1,113 @@
+use axum::routing::post;
+use axum::{extract::State, routing::get, Json, Router};
+
+use iron_db::{Paginated, Pagination};
+
+use ethers::types::Address;
+use ethers::{abi::Abi, types::Chain};
+use iron_types::UINotify;
+use iron_types::{events::Tx, Erc721TokenData, TokenBalance, U256};
+
+use crate::{Ctx, Error, Result};
+use serde::Deserialize;
+
+use iron_db::utils::{fetch_etherscan_abi, fetch_etherscan_contract_name};
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/transactions", get(transactions))
+        .route("/erc20_balances", get(erc20_balances))
+        .route("/native_balance", get(native_balance))
+        .route("/contracts", get(contracts))
+        .route("/contract_abi", get(contract_abi))
+        .route("/insert_contract", post(insert_contract))
+        .route("/erc721_tokens", get(erc721_tokens))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct TransactionsPayload {
+    address: Address,
+    chain_id: u32,
+    pagination: Option<Pagination>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AddressChainIdPayload {
+    address: Address,
+    chain_id: u32,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChainIdPayload {
+    chain_id: u32,
+}
+
+pub(crate) async fn transactions(
+    State(Ctx { db }): State<Ctx>,
+    Json(TransactionsPayload {
+        address,
+        chain_id,
+        pagination,
+    }): Json<TransactionsPayload>,
+) -> Result<Json<Paginated<Tx>>> {
+    Ok(Json(
+        db.get_transactions(chain_id, address, pagination.unwrap_or_default())
+            .await?,
+    ))
+}
+
+pub(crate) async fn erc20_balances(
+    State(Ctx { db }): State<Ctx>,
+    Json(AddressChainIdPayload { chain_id, address }): Json<AddressChainIdPayload>,
+) -> Result<Json<Vec<TokenBalance>>> {
+    Ok(Json(db.get_erc20_balances(chain_id, address).await?))
+}
+
+pub(crate) async fn native_balance(
+    State(Ctx { db }): State<Ctx>,
+    Json(AddressChainIdPayload { chain_id, address }): Json<AddressChainIdPayload>,
+) -> Result<Json<U256>> {
+    Ok(Json(db.get_native_balance(chain_id, address).await))
+}
+
+pub(crate) async fn contracts(
+    State(Ctx { db }): State<Ctx>,
+    Json(ChainIdPayload { chain_id }): Json<ChainIdPayload>,
+) -> Result<Json<Vec<Address>>> {
+    Ok(Json(db.get_contracts(chain_id).await?))
+}
+
+pub(crate) async fn contract_abi(
+    State(Ctx { db }): State<Ctx>,
+    Json(AddressChainIdPayload { chain_id, address }): Json<AddressChainIdPayload>,
+) -> Result<Json<Abi>> {
+    Ok(Json(db.get_contract_abi(chain_id, address).await?))
+}
+
+pub(crate) async fn insert_contract(
+    State(Ctx { db }): State<Ctx>,
+    Json(AddressChainIdPayload { chain_id, address }): Json<AddressChainIdPayload>,
+) -> Result<()> {
+    let chain = Chain::try_from(chain_id).map_err(|_| Error::InvalidChainId(chain_id))?;
+    let name = fetch_etherscan_contract_name(chain, address).await?;
+    let abi = fetch_etherscan_abi(chain, address)
+        .await?
+        .map(|abi| serde_json::to_string(&abi).unwrap());
+
+    db.insert_contract_with_abi(chain_id, address, abi, name)
+        .await?;
+
+    iron_broadcast::ui_notify(UINotify::ContractsUpdated).await;
+
+    Ok(())
+}
+
+pub(crate) async fn erc721_tokens(
+    State(Ctx { db }): State<Ctx>,
+    Json(AddressChainIdPayload { chain_id, address }): Json<AddressChainIdPayload>,
+) -> Result<Json<Vec<Erc721TokenData>>> {
+    Ok(Json(db.get_erc721_tokens(chain_id, address).await?))
+}

--- a/crates/http/src/routes/internals.rs
+++ b/crates/http/src/routes/internals.rs
@@ -1,0 +1,21 @@
+use axum::{routing::get, Router};
+
+use crate::Ctx;
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/build_mode", get(build_mode))
+        .route("/version", get(version))
+}
+
+pub(crate) async fn build_mode() -> String {
+    if cfg!(debug_assertions) {
+        "debug".to_string()
+    } else {
+        "release".to_string()
+    }
+}
+
+pub(crate) async fn version() -> String {
+    std::env!("CARGO_PKG_VERSION").replace('\"', "")
+}

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -6,10 +6,12 @@ mod connections;
 mod contracts;
 mod db;
 mod forge;
+mod internals;
 mod networks;
 mod rpc;
 mod settings;
 mod simulator;
+mod sync;
 mod wallets;
 mod ws;
 
@@ -24,9 +26,11 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/settings", settings::router())
                 .nest("/simulator", simulator::router())
+                .nest("/sync", sync::router())
                 .nest("/wallets", wallets::router())
                 .nest("/networks", networks::router())
-                .nest("/ws", ws::router()),
+                .nest("/ws", ws::router())
+                .nest("/internals", internals::router()),
         )
         .nest("/", rpc::router())
 }

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -4,6 +4,7 @@ use crate::Ctx;
 
 mod connections;
 mod contracts;
+mod db;
 mod forge;
 mod networks;
 mod rpc;
@@ -19,6 +20,7 @@ pub(crate) fn router() -> Router<Ctx> {
             Router::new()
                 .nest("/connections", connections::router())
                 .nest("/contracts", contracts::router())
+                .nest("/db", db::router())
                 .nest("/forge", forge::router())
                 .nest("/settings", settings::router())
                 .nest("/simulator", simulator::router())

--- a/crates/http/src/routes/sync.rs
+++ b/crates/http/src/routes/sync.rs
@@ -1,0 +1,20 @@
+use axum::{extract::Query, routing::get, Json, Router};
+use serde::Deserialize;
+
+use crate::Ctx;
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new().route("/alchemy_supported", get(alchemy_supported))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChainIdParams {
+    chain_id: u32,
+}
+
+pub(crate) async fn alchemy_supported(
+    Query(ChainIdParams { chain_id }): Query<ChainIdParams>,
+) -> Json<bool> {
+    Json(iron_sync_alchemy::supports_network(chain_id))
+}


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Implementing endpoints for the `iron-db` commands
* Updating the `iron-http` router to include the `/db` routes

Note: This PR is different from all the others in the sense I couldn't
use the fuctions that were annotated with `#[tauri::command]` directly
due to a `tauri::State` parameter. Given that most of the functions in
the `db/commands.rs` file are wrappers around the functionality, and we
can't create a `tauri::State`, the solution was to call the `db`
functions directly, where aplicable, and copy paste the command
implementation where needed
