### PR TITLE
Implement `/iron/sync/` endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,6 +3791,7 @@ dependencies = [
  "iron-rpc",
  "iron-settings",
  "iron-simulator",
+ "iron-sync-alchemy",
  "iron-types",
  "iron-wallets",
  "iron-ws",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -17,6 +17,7 @@ iron-networks = { workspace = true }
 iron-rpc = { workspace = true }
 iron-settings = { workspace = true }
 iron-simulator = { workspace = true }
+iron-sync-alchemy = { workspace = true }
 iron-types = { workspace = true }
 iron-wallets = { workspace = true }
 iron-ws = { workspace = true }

--- a/crates/http/src/routes/internals.rs
+++ b/crates/http/src/routes/internals.rs
@@ -1,0 +1,21 @@
+use axum::{routing::get, Router};
+
+use crate::Ctx;
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/build_mode", get(build_mode))
+        .route("/version", get(version))
+}
+
+pub(crate) async fn build_mode() -> String {
+    if cfg!(debug_assertions) {
+        "debug".to_string()
+    } else {
+        "release".to_string()
+    }
+}
+
+pub(crate) async fn version() -> String {
+    std::env!("CARGO_PKG_VERSION").replace('\"', "")
+}

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -10,6 +10,7 @@ mod networks;
 mod rpc;
 mod settings;
 mod simulator;
+mod sync;
 mod wallets;
 mod ws;
 
@@ -24,6 +25,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/forge", forge::router())
                 .nest("/settings", settings::router())
                 .nest("/simulator", simulator::router())
+                .nest("/sync", sync::router())
                 .nest("/wallets", wallets::router())
                 .nest("/networks", networks::router())
                 .nest("/ws", ws::router()),

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -6,6 +6,7 @@ mod connections;
 mod contracts;
 mod db;
 mod forge;
+mod internals;
 mod networks;
 mod rpc;
 mod settings;
@@ -28,7 +29,8 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/sync", sync::router())
                 .nest("/wallets", wallets::router())
                 .nest("/networks", networks::router())
-                .nest("/ws", ws::router()),
+                .nest("/ws", ws::router())
+                .nest("/internals", internals::router()),
         )
         .nest("/", rpc::router())
 }

--- a/crates/http/src/routes/sync.rs
+++ b/crates/http/src/routes/sync.rs
@@ -1,0 +1,20 @@
+use axum::{extract::Query, routing::get, Json, Router};
+use serde::Deserialize;
+
+use crate::Ctx;
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new().route("/alchemy_supported", get(alchemy_supported))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ChainIdParams {
+    chain_id: u32,
+}
+
+pub(crate) async fn alchemy_supported(
+    Query(ChainIdParams { chain_id }): Query<ChainIdParams>,
+) -> Json<bool> {
+    Json(iron_sync_alchemy::supports_network(chain_id))
+}


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Implementing endpoints for the `iron-sync` commands
* Updating the `iron-http` router to include the `/sync` routes
