### PR TITLE
Implement `/iron/internals/` endpoints

### DIFF
--- a/crates/http/src/routes/internals.rs
+++ b/crates/http/src/routes/internals.rs
@@ -1,0 +1,21 @@
+use axum::{routing::get, Router};
+
+use crate::Ctx;
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/build_mode", get(build_mode))
+        .route("/version", get(version))
+}
+
+pub(crate) async fn build_mode() -> String {
+    if cfg!(debug_assertions) {
+        "debug".to_string()
+    } else {
+        "release".to_string()
+    }
+}
+
+pub(crate) async fn version() -> String {
+    std::env!("CARGO_PKG_VERSION").replace('\"', "")
+}

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -6,6 +6,7 @@ mod connections;
 mod contracts;
 mod db;
 mod forge;
+mod internals;
 mod networks;
 mod rpc;
 mod settings;
@@ -28,7 +29,8 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/sync", sync::router())
                 .nest("/wallets", wallets::router())
                 .nest("/networks", networks::router())
-                .nest("/ws", ws::router()),
+                .nest("/ws", ws::router())
+                .nest("/internals", internals::router()),
         )
         .nest("/", rpc::router())
 }


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Implementing endpoints for the `iron` commands
* Updating the `iron-http` router to include the `/internals` routes
