### PR TITLE
Implement `/iron/transactions/` endpoints

### DIFF
--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
     Network(#[from] iron_networks::Error),
 
     #[error(transparent)]
+    RPC(#[from] iron_rpc::Error),
+
+    #[error(transparent)]
     Settings(#[from] iron_settings::Error),
 
     #[error(transparent)]

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -12,6 +12,7 @@ mod rpc;
 mod settings;
 mod simulator;
 mod sync;
+mod transactions;
 mod wallets;
 mod ws;
 
@@ -27,6 +28,7 @@ pub(crate) fn router() -> Router<Ctx> {
                 .nest("/settings", settings::router())
                 .nest("/simulator", simulator::router())
                 .nest("/sync", sync::router())
+                .nest("/transactions", transactions::router())
                 .nest("/wallets", wallets::router())
                 .nest("/networks", networks::router())
                 .nest("/ws", ws::router())

--- a/crates/http/src/routes/transactions.rs
+++ b/crates/http/src/routes/transactions.rs
@@ -1,0 +1,13 @@
+use axum::{routing::post, Json, Router};
+
+use crate::{Ctx, Result};
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new().route("/send_transaction", post(send_transaction))
+}
+
+pub(crate) async fn send_transaction(
+    Json(payload): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>> {
+    Ok(Json(iron_rpc::commands::rpc_send_transaction(payload).await?))
+}


### PR DESCRIPTION
Why:
* Continuing adding endpoints for issue #371

How:
* Adding a POST `/iron/transactions/send_transaction`
* Updating the `iron-http` router to include the `/transactions` routes
