### PR TITLE
Prevent `HDWalletCreateForm` `onSubmit` from being called multiple times

### DIFF
--- a/gui/src/components/Settings/Wallet/HDWallet.tsx
+++ b/gui/src/components/Settings/Wallet/HDWallet.tsx
@@ -72,9 +72,10 @@ function HDWalletCreateForm({
   const [derivationPath, setDerivationPath] = useState<string | null>(null);
   const [current, setCurrent] = useState<string | null>(null);
   const [password, setPassword] = useState("");
+  const [submitted, setSubmitted] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!current || !mnemonic || !derivationPath) return;
+    if (!current || !mnemonic || !derivationPath || submitted) return;
     // TODO
     onSubmit({
       type: wallet.type,
@@ -85,6 +86,7 @@ function HDWalletCreateForm({
       current,
       password,
     });
+    setSubmitted(true);
   }, [
     name,
     current,
@@ -93,6 +95,7 @@ function HDWalletCreateForm({
     password,
     wallet.type,
     onSubmit,
+    submitted,
   ]);
 
   return (


### PR DESCRIPTION
Why:

- `HDWalletCreateForm` `onSubmit` prop is a dependency of an `useEffect`, which may cause it to enter on an infinite loop when the component is re-rendered.

How:

- Add a new variable to the component state (`submitted`) to check if the `onSubmit` function was already called.