### PR TITLE
Fix extension build script to be compatible with MacOS

### DIFF
--- a/extension/scripts/build.sh
+++ b/extension/scripts/build.sh
@@ -52,9 +52,9 @@ yarn run vite build --config vite/background.ts
 mv $DIST_DIR/manifest-$target.json $DIST_DIR/manifest.json
 rm $DIST_DIR/manifest-*.json
 
-SED_ARGS="--in-place"
+SED_ARGS="-i"
 if [ "$(uname -s)" == "Darwin" ]; then
-  SED_ARGS='--in-place ""'
+  SED_ARGS='-i ""'
 fi
 sed $SED_ARGS "s/%VERSION%/$version/g" $DIST_DIR/manifest.json
 

--- a/extension/scripts/build.sh
+++ b/extension/scripts/build.sh
@@ -31,11 +31,6 @@ while [ : ]; do
   esac
 done
 
-SED_ARGS="-i"
-
-if [ "$(uname -s)" == "Darwin" ]; then
-  SED_ARGS='-i ""'
-fi
 
 #
 # building
@@ -57,6 +52,10 @@ yarn run vite build --config vite/background.ts
 mv $DIST_DIR/manifest-$target.json $DIST_DIR/manifest.json
 rm $DIST_DIR/manifest-*.json
 
+SED_ARGS="--in-place"
+if [ "$(uname -s)" == "Darwin" ]; then
+  SED_ARGS='--in-place ""'
+fi
 sed $SED_ARGS "s/%VERSION%/$version/g" $DIST_DIR/manifest.json
 
 # create zip

--- a/extension/scripts/build.sh
+++ b/extension/scripts/build.sh
@@ -31,6 +31,12 @@ while [ : ]; do
   esac
 done
 
+SED_ARGS="-i"
+
+if [ "$(uname -s)" == "Darwin" ]; then
+  SED_ARGS='-i ""'
+fi
+
 #
 # building
 #
@@ -50,7 +56,8 @@ yarn run vite build --config vite/background.ts
 # choose manifest
 mv $DIST_DIR/manifest-$target.json $DIST_DIR/manifest.json
 rm $DIST_DIR/manifest-*.json
-sed -i 's/%VERSION%/'$version'/g' $DIST_DIR/manifest.json
+
+sed $SED_ARGS "s/%VERSION%/$version/g" $DIST_DIR/manifest.json
 
 # create zip
 (cd $DIST_DIR && zip -r ../$basename.zip .)


### PR DESCRIPTION
Why:
* #453

How:
* Using the `uname` command to check if the OS that is running the
  script is MacOS. If it is, changing the arguments passed to `sed`
* Changing the single quotes around the substitute argument to double
  quotes in order for bash string interpolation to work correctly
