### PR TITLE
Stabilizes extension connection

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -39,6 +39,6 @@
     "mipd": "^0.0.5",
     "stream": "^0.0.2",
     "webextension-polyfill": "^0.10.0",
-    "websocket-ts": "^1.1.1"
+    "websocket-ts": "^2.1.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9306,10 +9306,10 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-websocket-ts@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/websocket-ts/-/websocket-ts-1.1.1.tgz#de482da5e0c714ebc58a43fe94157e5a855f2828"
-  integrity sha512-rm+S60J74Ckw5iizzgID12ju+OfaHAa6dhXhULIOrXkl0e05RzxfY42/vMStpz5jWL3iz9mkyjPcFUY1IgI0fw==
+websocket-ts@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/websocket-ts/-/websocket-ts-2.1.5.tgz#b6b51f0afca89d6bc7ff71c9e74540f19ae0262c"
+  integrity sha512-rCNl9w6Hsir1azFm/pbjBEFzLD/gi7Th5ZgOxMifB6STUfTSovYAzryWw0TRvSZ1+Qu1Z5Plw4z42UfTNA9idA==
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Previously, we had some finicky behaviour with the extension randomly disconnect, and sometimes requiring us to refresh the page twice before it would pick up the ws connection again

With the new version of `websocket-ts`, re-connecting is much smoother, and a builtin ArrayQueue is already included to buffer messages while disconnected.
This both simplifies our custom logic but also makes re-connection logic a lot more stable