### PR TITLE
Fix stuck onboarding

### DIFF
--- a/crates/http/src/routes/settings.rs
+++ b/crates/http/src/routes/settings.rs
@@ -31,7 +31,7 @@ pub(crate) struct SetSettings {
 }
 
 pub(crate) async fn set_settings(
-    Json(payload): Json<serde_json::Map<String, serde_json::Value>>,
+    Json(payload): Json<SetSettings>,
 ) -> Result<()> {
     iron_settings::commands::settings_set(payload.new_settings).await?;
 


### PR DESCRIPTION
Why:
* After a clean install, the onboarding wizard is shown. However,
  there's an issue that prevents the user to either skip or finish the
  onboarding. In the `Wizard.tsx` file, there's a call to the
  `settings_set` endpoint that passes the `newSettings` key, and the
  endpoint is expecting `new_settings`

How:
* Using the `SetSettings` struct as the type for the `set_settings`
  functions in the http settings crate so that we make use of Serde's
  `rename_all` to convert the params from camelCase to snake_case
