### PR TITLE
Hotfix: remove unexpected window title and the window not being draggable

### DIFF
--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -144,7 +144,9 @@ async fn build_main_window(app: &tauri::App) -> tauri::Result<Window<Wry>> {
         .inner_size(600.0, 800.0);
 
     #[cfg(target_os = "macos")]
-    let builder = builder.title_bar_style(tauri::TitleBarStyle::Overlay);
+    let builder = builder
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true);
 
     builder.build()
 }

--- a/gui/src/components/DraggableToolbar.tsx
+++ b/gui/src/components/DraggableToolbar.tsx
@@ -1,0 +1,5 @@
+import { Toolbar } from "@mui/material";
+
+export function DraggableToolbar(props: Parameters<typeof Toolbar>[0]) {
+  return <Toolbar data-tauri-drag-region="true" {...props} />;
+}

--- a/gui/src/components/Navbar.tsx
+++ b/gui/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
-import { AppBar, Toolbar, Typography } from "@mui/material";
+import { AppBar, Typography } from "@mui/material";
 
+import { DraggableToolbar } from "./DraggableToolbar";
 import { TABS } from "./Sidebar";
 
 export function Navbar({ tab }: { tab: (typeof TABS)[number] }) {
@@ -11,11 +12,11 @@ export function Navbar({ tab }: { tab: (typeof TABS)[number] }) {
         borderBottomWidth: 1,
       }}
     >
-      <Toolbar data-tauri-drag-region="true">
+      <DraggableToolbar>
         <Typography variant="h6" component="div">
           {tab.name}
         </Typography>
-      </Toolbar>
+      </DraggableToolbar>
     </AppBar>
   );
 }

--- a/gui/src/components/Onboarding/index.tsx
+++ b/gui/src/components/Onboarding/index.tsx
@@ -1,11 +1,12 @@
-import { Box, Container, MobileStepper, Stack, Toolbar } from "@mui/material";
+import { Container, MobileStepper, Stack } from "@mui/material";
 import { useState } from "react";
+
+import { DraggableToolbar } from "@/components";
 
 import { AlchemyStep } from "./Alchemy";
 import { InstallExtensionStep } from "./Extension";
 import { ThankYouStep } from "./ThankYou";
 import { WelcomeStep } from "./Welcome";
-import { DraggableToolbar } from "../DraggableToolbar";
 
 export interface StepProps {
   onSubmit: () => unknown;

--- a/gui/src/components/Onboarding/index.tsx
+++ b/gui/src/components/Onboarding/index.tsx
@@ -1,10 +1,11 @@
-import { Box, Container, MobileStepper, Stack } from "@mui/material";
+import { Box, Container, MobileStepper, Stack, Toolbar } from "@mui/material";
 import { useState } from "react";
 
 import { AlchemyStep } from "./Alchemy";
 import { InstallExtensionStep } from "./Extension";
 import { ThankYouStep } from "./ThankYou";
 import { WelcomeStep } from "./Welcome";
+import { DraggableToolbar } from "../DraggableToolbar";
 
 export interface StepProps {
   onSubmit: () => unknown;
@@ -30,7 +31,7 @@ export function Onboarding() {
 
   return (
     <>
-      <Box sx={{ height: 64 }} data-tauri-drag-region="true"></Box>
+      <DraggableToolbar></DraggableToolbar>
       <Container disableGutters maxWidth="sm" sx={{ mt: 8, mb: 10, px: 3 }}>
         <Stack alignItems="center">
           <step.component onSubmit={handleNext} />

--- a/gui/src/components/Onboarding/index.tsx
+++ b/gui/src/components/Onboarding/index.tsx
@@ -1,4 +1,4 @@
-import { Container, MobileStepper, Stack } from "@mui/material";
+import { Box, Container, MobileStepper, Stack } from "@mui/material";
 import { useState } from "react";
 
 import { AlchemyStep } from "./Alchemy";
@@ -29,18 +29,21 @@ export function Onboarding() {
   const step = steps[activeStep];
 
   return (
-    <Container disableGutters maxWidth="sm" sx={{ mt: 8, mb: 10, px: 3 }}>
-      <Stack alignItems="center">
-        <step.component onSubmit={handleNext} />
+    <>
+      <Box sx={{ height: 64 }} data-tauri-drag-region="true"></Box>
+      <Container disableGutters maxWidth="sm" sx={{ mt: 8, mb: 10, px: 3 }}>
+        <Stack alignItems="center">
+          <step.component onSubmit={handleNext} />
 
-        <MobileStepper
-          steps={steps.length}
-          position="static"
-          activeStep={activeStep}
-          nextButton={<></>}
-          backButton={<></>}
-        />
-      </Stack>
-    </Container>
+          <MobileStepper
+            steps={steps.length}
+            position="static"
+            activeStep={activeStep}
+            nextButton={<></>}
+            backButton={<></>}
+          />
+        </Stack>
+      </Container>
+    </>
   );
 }

--- a/gui/src/components/Onboarding/index.tsx
+++ b/gui/src/components/Onboarding/index.tsx
@@ -32,7 +32,7 @@ export function Onboarding() {
 
   return (
     <>
-      <DraggableToolbar></DraggableToolbar>
+      <DraggableToolbar />
       <Container disableGutters maxWidth="sm" sx={{ mt: 8, mb: 10, px: 3 }}>
         <Stack alignItems="center">
           <step.component onSubmit={handleNext} />

--- a/gui/src/components/index.ts
+++ b/gui/src/components/index.ts
@@ -12,6 +12,7 @@ export { Contracts } from "./Contracts";
 export { CopyToClipboard } from "./CopyToClipboard";
 export { Datapoint } from "./Datapoint";
 export { DevBuildNotice } from "./DevBuildNotice";
+export { DraggableToolbar } from "./DraggableToolbar";
 export { ErrorHandler } from "./ErrorHandler";
 export { HomePage } from "./HomePage";
 export { IconCrypto } from "./IconCrypto";


### PR DESCRIPTION
* Add a draggable element to onboarding.
* Hide the titlebar on macos.