### PR TITLE
Better 'from' detection when submitting transactionss

### DIFF
--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -2,6 +2,7 @@ use ethers::{
     core::k256::ecdsa::SigningKey,
     prelude::{signer::SignerMiddlewareError, *},
     signers,
+    types::Address,
 };
 use jsonrpc_core::ErrorCode;
 
@@ -12,6 +13,9 @@ pub enum Error {
 
     #[error("Signature rejected")]
     SignatureRejected,
+
+    #[error("Unknown wallet: {0}")]
+    WalletNotFound(Address),
 
     #[error("Error building signer: {0}")]
     SignerBuild(String),

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -170,19 +170,13 @@ impl Handler {
     ) -> jsonrpc_core::Result<serde_json::Value> {
         use send_transaction::SendTransaction;
 
-        let wallets = Wallets::read().await;
-
-        let network = ctx.network().await;
-        let wallet = wallets.get_current_wallet();
-
-        // TODO: send correct path instead of hardcode to current
         // TODO: check that requested wallet is authorized
-        let mut sender = SendTransaction::build()
-            .set_wallet(wallet)
-            .set_wallet_path(wallet.get_current_path())
-            .set_network(network)
+        let mut sender = SendTransaction::build(&ctx)
             .set_request(params.into())
-            .build();
+            .await
+            .unwrap()
+            .build()
+            .await;
 
         let result = sender.estimate_gas().await.finish().await;
 

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -36,9 +36,23 @@ pub struct Wallets {
 }
 
 impl Wallets {
+    pub async fn find(&self, address: ChecksummedAddress) -> Option<(&Wallet, String)> {
+        for w in self.wallets.iter() {
+            if let Some(path) = w.find(address).await {
+                return Some((w, path));
+            }
+        }
+
+        None
+    }
+
     /// Gets a reference the current default wallet
     pub fn get_current_wallet(&self) -> &Wallet {
         &self.wallets[self.current]
+    }
+
+    pub fn get(&self, name: &str) -> Option<&Wallet> {
+        self.wallets.iter().find(|w| w.name() == name)
     }
 
     /// Sets the current key within the current default

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -34,6 +34,18 @@ pub trait WalletControl: Sync + Send + Deserialize<'static> + Serialize + std::f
         self.build_signer(chain_id, &self.get_current_path()).await
     }
 
+    async fn find(&self, address: ChecksummedAddress) -> Option<String> {
+        let addresses = self.get_all_addresses().await;
+
+        addresses.iter().find_map(|(path, addr)| {
+            if *addr == address {
+                Some(path.clone())
+            } else {
+                None
+            }
+        })
+    }
+
     fn is_dev(&self) -> bool {
         false
     }

--- a/gui/src/components/ABIForm.tsx
+++ b/gui/src/components/ABIForm.tsx
@@ -1,4 +1,11 @@
-import { Autocomplete, Box, Button, Chip, TextField } from "@mui/material";
+import {
+  Autocomplete,
+  Box,
+  Button,
+  Chip,
+  TextField,
+  Typography,
+} from "@mui/material";
 import { Stack } from "@mui/system";
 import { invoke } from "@tauri-apps/api/tauri";
 import { Abi, AbiFunction, formatAbiItem } from "abitype";
@@ -114,7 +121,12 @@ function ItemForm({ contract, item }: ItemFormProps) {
       }
     } else {
       const result = await invoke<string>("rpc_send_transaction", {
-        params: { to: contract, value: params.value, data },
+        params: {
+          from: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+          to: contract,
+          value: params.value,
+          data,
+        },
       });
       setTxResult(result);
     }
@@ -148,8 +160,8 @@ function ItemForm({ contract, item }: ItemFormProps) {
             {item.stateMutability == "view" ? "Call" : "Send"}
           </Button>
         </Box>
-        {callResult && <Box>{callResult}</Box>}
-        {txResult && <Box>{txResult}</Box>}
+        {callResult && <Typography>{callResult}</Typography>}
+        {txResult && <Typography>{txResult}</Typography>}
       </Stack>
     </form>
   );


### PR DESCRIPTION
This solves a long-standing issue (#426) where submitting a transaction with a different `"from"` than what that tab's connection was currently using would result in incorrect behavior (i.e. showing the wrong address on the UI)