### PR TITLE
Add homepage guided tour

### DIFF
--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -32,6 +32,7 @@ impl IronApp {
                 iron_settings::commands::settings_set_dark_mode,
                 iron_settings::commands::settings_set_fast_mode,
                 iron_settings::commands::settings_finish_onboarding,
+                iron_settings::commands::settings_finish_homepage_tour,
                 iron_settings::commands::settings_set_alias,
                 iron_settings::commands::settings_get_alias,
                 iron_settings::commands::settings_test_alchemy_api_key,

--- a/crates/http/src/routes/settings.rs
+++ b/crates/http/src/routes/settings.rs
@@ -16,6 +16,7 @@ pub(super) fn router() -> Router<Ctx> {
         .route("/set_dark_mode", post(set_dark_mode))
         .route("/set_fast_mode", post(set_fast_mode))
         .route("/finish_onboarding", post(finish_onboarding))
+        .route("/finish_homepage_tour", post(finish_homepage_tour))
         .route("/alias", get(alias))
         .route("/alias", post(set_alias))
 }
@@ -60,6 +61,12 @@ pub(crate) async fn set_fast_mode(Json(params): Json<SetFastModePayload>) -> Res
 
 pub(crate) async fn finish_onboarding() -> Result<()> {
     iron_settings::commands::settings_finish_onboarding().await?;
+
+    Ok(())
+}
+
+pub(crate) async fn finish_homepage_tour() -> Result<()> {
+    iron_settings::commands::settings_finish_homepage_tour().await?;
 
     Ok(())
 }

--- a/crates/settings/src/commands.rs
+++ b/crates/settings/src/commands.rs
@@ -27,6 +27,11 @@ pub async fn settings_finish_onboarding() -> Result<()> {
     Settings::write().await.finish_onboarding().await
 }
 
+#[tauri::command]
+pub async fn settings_finish_homepage_tour() -> Result<()> {
+    Settings::write().await.finish_homepage_tour().await
+}
+
 /// Gets the alias for an address
 #[tauri::command]
 pub async fn settings_get_alias(address: Address) -> Option<String> {

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -80,12 +80,23 @@ impl Settings {
         Ok(())
     }
 
+    pub async fn finish_homepage_tour(&mut self) -> Result<()> {
+        self.inner.homepage_tour_completed = true;
+        self.save().await?;
+
+        Ok(())
+    }
+
     pub fn get(&self) -> &SerializedSettings {
         &self.inner
     }
 
     pub fn onboarded(&self) -> bool {
         self.inner.onboarded
+    }
+
+    pub fn homepage_tour_completed(&self) -> bool {
+        self.inner.homepage_tour_completed
     }
 
     pub fn fast_mode(&self) -> bool {
@@ -147,6 +158,9 @@ pub struct SerializedSettings {
     onboarded: bool,
 
     #[serde(default)]
+    homepage_tour_completed: bool,
+
+    #[serde(default)]
     fast_mode: bool,
 }
 
@@ -160,6 +174,7 @@ impl Default for SerializedSettings {
             hide_empty_tokens: true,
             aliases: HashMap::new(),
             onboarded: false,
+            homepage_tour_completed: false,
             fast_mode: false,
         }
     }

--- a/gui/package.json
+++ b/gui/package.json
@@ -20,6 +20,7 @@
     "@mui/icons-material": "^5.14.16",
     "@mui/lab": "^5.0.0-alpha.151",
     "@mui/material": "^5.14.0",
+    "@reactour/tour": "^3.6.1",
     "@tauri-apps/api": "^1.5.0",
     "@tauri-apps/cli": "^1.5.0",
     "abitype": "^0.10.2",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -3,6 +3,7 @@ import "react18-json-view/src/style.css";
 
 import { GlobalStyles, ThemeProvider } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
+import { StylesObj, TourProvider } from "@reactour/tour";
 import { SnackbarProvider } from "notistack";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Route, Router, Switch } from "wouter";
@@ -35,6 +36,32 @@ const globalStyles = {
   h3: { userSelect: "initial" },
 };
 
+const styles = {
+  popover: (base: StylesObj) => ({
+    ...base,
+    color: "black",
+  }),
+};
+
+const steps = [
+  {
+    selector: '[data-tour="step-1"]',
+    content: "This is the first Step",
+  },
+  {
+    selector: '[data-tour="step-2"]',
+    content: "This is the first Step",
+  },
+  {
+    selector: '[data-tour="step-3"]',
+    content: "This is the first Step",
+  },
+  {
+    selector: '[data-tour="step-4"]',
+    content: "This is the first Step",
+  },
+];
+
 export default function App() {
   const theme = useTheme((s) => s.theme);
 
@@ -42,14 +69,21 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <GlobalStyles styles={globalStyles} />
       <CssBaseline>
-        <ErrorHandler>
-          <QueryClientProvider client={queryClient}>
-            <DevBuildNotice />
-            <WagmiWrapper>
-              <Routes />
-            </WagmiWrapper>
-          </QueryClientProvider>
-        </ErrorHandler>
+        <TourProvider
+          steps={steps}
+          styles={styles}
+          showCloseButton={false}
+          disableInteraction
+        >
+          <ErrorHandler>
+            <QueryClientProvider client={queryClient}>
+              <DevBuildNotice />
+              <WagmiWrapper>
+                <Routes />
+              </WagmiWrapper>
+            </QueryClientProvider>
+          </ErrorHandler>
+        </TourProvider>
       </CssBaseline>
     </ThemeProvider>
   );

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -3,6 +3,7 @@ import "react18-json-view/src/style.css";
 
 import { GlobalStyles, ThemeProvider } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
+import { invoke } from "@tauri-apps/api/tauri";
 import { SnackbarProvider } from "notistack";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Route, Router, Switch } from "wouter";
@@ -20,9 +21,9 @@ import {
   WalletUnlockDialog,
 } from "@/components/Dialogs";
 import { Onboarding } from "@/components/Onboarding";
-
-import TourWrapper from "./components/Tour";
-import { useTheme } from "./store/theme";
+import TourWrapper from "@/components/Tour";
+import { homepageSteps } from "@/components/Tour/Steps";
+import { useTheme } from "@/store/theme";
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { suspense: true } },
@@ -82,7 +83,10 @@ function Routes() {
             dense
           >
             <CommandBar>
-              <TourWrapper>
+              <TourWrapper
+                onClose={() => invoke("settings_finish_homepage_tour")}
+                steps={homepageSteps}
+              >
                 <HomePage />
               </TourWrapper>
             </CommandBar>

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -3,7 +3,6 @@ import "react18-json-view/src/style.css";
 
 import { GlobalStyles, ThemeProvider } from "@mui/material";
 import CssBaseline from "@mui/material/CssBaseline";
-import { StylesObj, TourProvider } from "@reactour/tour";
 import { SnackbarProvider } from "notistack";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { Route, Router, Switch } from "wouter";
@@ -22,6 +21,7 @@ import {
 } from "@/components/Dialogs";
 import { Onboarding } from "@/components/Onboarding";
 
+import TourWrapper from "./components/Tour";
 import { useTheme } from "./store/theme";
 
 const queryClient = new QueryClient({
@@ -36,32 +36,6 @@ const globalStyles = {
   h3: { userSelect: "initial" },
 };
 
-const styles = {
-  popover: (base: StylesObj) => ({
-    ...base,
-    color: "black",
-  }),
-};
-
-const steps = [
-  {
-    selector: '[data-tour="step-1"]',
-    content: "This is the first Step",
-  },
-  {
-    selector: '[data-tour="step-2"]',
-    content: "This is the first Step",
-  },
-  {
-    selector: '[data-tour="step-3"]',
-    content: "This is the first Step",
-  },
-  {
-    selector: '[data-tour="step-4"]',
-    content: "This is the first Step",
-  },
-];
-
 export default function App() {
   const theme = useTheme((s) => s.theme);
 
@@ -69,21 +43,14 @@ export default function App() {
     <ThemeProvider theme={theme}>
       <GlobalStyles styles={globalStyles} />
       <CssBaseline>
-        <TourProvider
-          steps={steps}
-          styles={styles}
-          showCloseButton={false}
-          disableInteraction
-        >
-          <ErrorHandler>
-            <QueryClientProvider client={queryClient}>
-              <DevBuildNotice />
-              <WagmiWrapper>
-                <Routes />
-              </WagmiWrapper>
-            </QueryClientProvider>
-          </ErrorHandler>
-        </TourProvider>
+        <ErrorHandler>
+          <QueryClientProvider client={queryClient}>
+            <DevBuildNotice />
+            <WagmiWrapper>
+              <Routes />
+            </WagmiWrapper>
+          </QueryClientProvider>
+        </ErrorHandler>
       </CssBaseline>
     </ThemeProvider>
   );
@@ -115,7 +82,9 @@ function Routes() {
             dense
           >
             <CommandBar>
-              <HomePage />
+              <TourWrapper>
+                <HomePage />
+              </TourWrapper>
             </CommandBar>
           </SnackbarProvider>
         </Route>

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -2,22 +2,31 @@ import { useTour } from "@reactour/tour";
 import { useEffect } from "react";
 import { Route, Switch } from "wouter";
 
-import { useNoticeAlchemyKeyMissing, useNoticeNewVersion } from "@/hooks";
+import {
+  useInvoke,
+  useNoticeAlchemyKeyMissing,
+  useNoticeNewVersion,
+} from "@/hooks";
+import { GeneralSettings } from "@/types";
 
 import { ErrorHandler, Navbar, NestedRoutes } from "./";
 import { DEFAULT_TAB, SidebarLayout, TABS } from "./Sidebar";
 
 export function HomePage() {
   const { setIsOpen } = useTour();
+  const { data: settings } = useInvoke<GeneralSettings>("settings_get");
 
   useNoticeAlchemyKeyMissing();
   useNoticeNewVersion();
 
   useEffect(() => {
-    setTimeout(() => {
-      setIsOpen(true);
-    }, 1000);
-  }, [setIsOpen]);
+    if (!settings) return;
+
+    if (!settings.homepageTourCompleted)
+      setTimeout(() => {
+        setIsOpen(true);
+      }, 500);
+  }, [setIsOpen, settings, settings?.homepageTourCompleted]);
 
   return (
     <SidebarLayout>

--- a/gui/src/components/HomePage.tsx
+++ b/gui/src/components/HomePage.tsx
@@ -1,3 +1,5 @@
+import { useTour } from "@reactour/tour";
+import { useEffect } from "react";
 import { Route, Switch } from "wouter";
 
 import { useNoticeAlchemyKeyMissing, useNoticeNewVersion } from "@/hooks";
@@ -6,8 +8,16 @@ import { ErrorHandler, Navbar, NestedRoutes } from "./";
 import { DEFAULT_TAB, SidebarLayout, TABS } from "./Sidebar";
 
 export function HomePage() {
+  const { setIsOpen } = useTour();
+
   useNoticeAlchemyKeyMissing();
   useNoticeNewVersion();
+
+  useEffect(() => {
+    setTimeout(() => {
+      setIsOpen(true);
+    }, 1000);
+  }, [setIsOpen]);
 
   return (
     <SidebarLayout>

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -178,12 +178,12 @@ export function Sidebar() {
               },
             }}
           >
-            <div data-tour="step-1">
+            <div data-homepage-tour="quick-select">
               <QuickWalletSelect />
               <QuickAddressSelect />
               <QuickNetworkSelect />
             </div>
-            <div data-tour="step-2">
+            <div data-homepage-tour="fast-mode">
               <QuickFastModeToggle />
             </div>
           </Stack>
@@ -196,7 +196,7 @@ export function Sidebar() {
               },
             }}
           >
-            <div data-tour="step-3">
+            <div data-homepage-tour="command-bar">
               <CommandBarButton />
             </div>
             <SettingsButton />

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -178,9 +178,15 @@ export function Sidebar() {
               },
             }}
           >
-            <QuickWalletSelect />
-            <QuickAddressSelect />
-            <QuickNetworkSelect />
+            <div data-tour="step-1">
+              <QuickWalletSelect />
+            </div>
+            <div data-tour="step-2">
+              <QuickAddressSelect />
+            </div>
+            <div data-tour="step-3">
+              <QuickNetworkSelect />
+            </div>
             <QuickFastModeToggle />
           </Stack>
           <Stack
@@ -192,7 +198,9 @@ export function Sidebar() {
               },
             }}
           >
-            <CommandBarButton />
+            <div data-tour="step-4">
+              <CommandBarButton />
+            </div>
             <SettingsButton />
           </Stack>
         </Box>

--- a/gui/src/components/Sidebar.tsx
+++ b/gui/src/components/Sidebar.tsx
@@ -180,14 +180,12 @@ export function Sidebar() {
           >
             <div data-tour="step-1">
               <QuickWalletSelect />
-            </div>
-            <div data-tour="step-2">
               <QuickAddressSelect />
-            </div>
-            <div data-tour="step-3">
               <QuickNetworkSelect />
             </div>
-            <QuickFastModeToggle />
+            <div data-tour="step-2">
+              <QuickFastModeToggle />
+            </div>
           </Stack>
           <Stack
             p={3}
@@ -198,7 +196,7 @@ export function Sidebar() {
               },
             }}
           >
-            <div data-tour="step-4">
+            <div data-tour="step-3">
               <CommandBarButton />
             </div>
             <SettingsButton />

--- a/gui/src/components/Tour/Content.tsx
+++ b/gui/src/components/Tour/Content.tsx
@@ -1,0 +1,48 @@
+import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
+import CloseIcon from "@mui/icons-material/Close";
+import { Button, Container, MobileStepper, Stack } from "@mui/material";
+import { PopoverContentProps } from "@reactour/tour";
+
+export default function ContentComponent(props: PopoverContentProps) {
+  const isFirstStep = props.currentStep === 0;
+  const isLastStep = props.currentStep === props.steps.length - 1;
+  const content = props.steps[props.currentStep].content;
+
+  return (
+    <Container disableGutters>
+      <Stack
+        direction="column"
+        justifyContent="space-between"
+        alignItems="stretch"
+      >
+        <Button sx={{ alignSelf: "end" }}>
+          <CloseIcon />
+        </Button>
+
+        <Container sx={{ minHeight: 85 }}>{content as string}</Container>
+
+        <MobileStepper
+          steps={props.steps.length}
+          position="static"
+          activeStep={props.currentStep}
+          backButton={
+            <Button
+              onClick={() => props.setCurrentStep((s) => s - 1)}
+              disabled={isFirstStep}
+            >
+              <KeyboardArrowLeft />
+            </Button>
+          }
+          nextButton={
+            <Button
+              onClick={() => props.setCurrentStep((s) => s + 1)}
+              disabled={isLastStep}
+            >
+              <KeyboardArrowRight />
+            </Button>
+          }
+        />
+      </Stack>
+    </Container>
+  );
+}

--- a/gui/src/components/Tour/Content.tsx
+++ b/gui/src/components/Tour/Content.tsx
@@ -10,7 +10,7 @@ import {
 import { PopoverContentProps } from "@reactour/tour";
 
 export default function ContentComponent(props: PopoverContentProps) {
-  const { steps, currentStep, setCurrentStep } = props;
+  const { steps, currentStep, setCurrentStep, setIsOpen, onClickClose } = props;
 
   const isFirstStep = currentStep === 0;
   const isLastStep = currentStep === steps.length - 1;
@@ -23,7 +23,17 @@ export default function ContentComponent(props: PopoverContentProps) {
         justifyContent="space-between"
         alignItems="stretch"
       >
-        <Button sx={{ alignSelf: "end" }}>
+        <Button
+          sx={{ alignSelf: "end" }}
+          onClick={() => {
+            if (isLastStep) {
+              onClickClose();
+              setIsOpen(false);
+            } else {
+              setCurrentStep((s) => s + 1);
+            }
+          }}
+        >
           <CloseIcon />
         </Button>
 

--- a/gui/src/components/Tour/Content.tsx
+++ b/gui/src/components/Tour/Content.tsx
@@ -1,12 +1,20 @@
 import { KeyboardArrowLeft, KeyboardArrowRight } from "@mui/icons-material";
 import CloseIcon from "@mui/icons-material/Close";
-import { Button, Container, MobileStepper, Stack } from "@mui/material";
+import {
+  Button,
+  Container,
+  MobileStepper,
+  Stack,
+  Typography,
+} from "@mui/material";
 import { PopoverContentProps } from "@reactour/tour";
 
 export default function ContentComponent(props: PopoverContentProps) {
-  const isFirstStep = props.currentStep === 0;
-  const isLastStep = props.currentStep === props.steps.length - 1;
-  const content = props.steps[props.currentStep].content;
+  const { steps, currentStep, setCurrentStep } = props;
+
+  const isFirstStep = currentStep === 0;
+  const isLastStep = currentStep === steps.length - 1;
+  const content = steps[currentStep].content as string;
 
   return (
     <Container disableGutters>
@@ -19,23 +27,25 @@ export default function ContentComponent(props: PopoverContentProps) {
           <CloseIcon />
         </Button>
 
-        <Container sx={{ minHeight: 85 }}>{content as string}</Container>
+        <Container>
+          <Typography>{content}</Typography>
+        </Container>
 
         <MobileStepper
-          steps={props.steps.length}
+          steps={steps.length}
           position="static"
-          activeStep={props.currentStep}
+          activeStep={currentStep}
           backButton={
             <Button
-              onClick={() => props.setCurrentStep((s) => s - 1)}
               disabled={isFirstStep}
+              onClick={() => setCurrentStep((s) => s - 1)}
             >
               <KeyboardArrowLeft />
             </Button>
           }
           nextButton={
             <Button
-              onClick={() => props.setCurrentStep((s) => s + 1)}
+              onClick={() => setCurrentStep((s) => s + 1)}
               disabled={isLastStep}
             >
               <KeyboardArrowRight />

--- a/gui/src/components/Tour/PopoverContent.tsx
+++ b/gui/src/components/Tour/PopoverContent.tsx
@@ -36,7 +36,11 @@ export default function PopoverContent(props: PopoverContentProps) {
         justifyContent="space-between"
         alignItems="stretch"
       >
-        <Button sx={{ alignSelf: "end" }} onClick={onClickCloseButton}>
+        <Button
+          sx={{ alignSelf: "end" }}
+          disabled={!isLastStep}
+          onClick={onClickCloseButton}
+        >
           <CloseIcon />
         </Button>
 

--- a/gui/src/components/Tour/PopoverContent.tsx
+++ b/gui/src/components/Tour/PopoverContent.tsx
@@ -16,6 +16,19 @@ export default function PopoverContent(props: PopoverContentProps) {
   const isLastStep = currentStep === steps.length - 1;
   const content = steps[currentStep].content as string;
 
+  const previousStep = () => setCurrentStep((s) => s - 1);
+
+  const nextStep = () => setCurrentStep((s) => s + 1);
+
+  const onClickCloseButton = () => {
+    if (isLastStep && onClickClose) {
+      onClickClose({ setIsOpen, setCurrentStep, currentStep });
+      setIsOpen(false);
+    } else {
+      nextStep();
+    }
+  };
+
   return (
     <Container disableGutters>
       <Stack
@@ -23,17 +36,7 @@ export default function PopoverContent(props: PopoverContentProps) {
         justifyContent="space-between"
         alignItems="stretch"
       >
-        <Button
-          sx={{ alignSelf: "end" }}
-          onClick={() => {
-            if (isLastStep) {
-              onClickClose();
-              setIsOpen(false);
-            } else {
-              setCurrentStep((s) => s + 1);
-            }
-          }}
-        >
+        <Button sx={{ alignSelf: "end" }} onClick={onClickCloseButton}>
           <CloseIcon />
         </Button>
 
@@ -46,18 +49,12 @@ export default function PopoverContent(props: PopoverContentProps) {
           position="static"
           activeStep={currentStep}
           backButton={
-            <Button
-              disabled={isFirstStep}
-              onClick={() => setCurrentStep((s) => s - 1)}
-            >
+            <Button disabled={isFirstStep} onClick={previousStep}>
               <KeyboardArrowLeft />
             </Button>
           }
           nextButton={
-            <Button
-              onClick={() => setCurrentStep((s) => s + 1)}
-              disabled={isLastStep}
-            >
+            <Button disabled={isLastStep} onClick={nextStep}>
               <KeyboardArrowRight />
             </Button>
           }

--- a/gui/src/components/Tour/PopoverContent.tsx
+++ b/gui/src/components/Tour/PopoverContent.tsx
@@ -9,7 +9,7 @@ import {
 } from "@mui/material";
 import { PopoverContentProps } from "@reactour/tour";
 
-export default function ContentComponent(props: PopoverContentProps) {
+export default function PopoverContent(props: PopoverContentProps) {
   const { steps, currentStep, setCurrentStep, setIsOpen, onClickClose } = props;
 
   const isFirstStep = currentStep === 0;

--- a/gui/src/components/Tour/Steps.tsx
+++ b/gui/src/components/Tour/Steps.tsx
@@ -1,15 +1,15 @@
 export const homepageSteps = [
   {
-    selector: '[data-tour="step-1"]',
+    selector: '[data-homepage-tour="quick-select"]',
     content: "Here you can quickly switch wallet, address and network.",
   },
   {
-    selector: '[data-tour="step-2"]',
+    selector: '[data-homepage-tour="fast-mode"]',
     content:
       "Skip confirmation dialog when using a plaintext wallet on the anvil network.",
   },
   {
-    selector: '[data-tour="step-3"]',
+    selector: '[data-homepage-tour="command-bar"]',
     content:
       "The main navigation tool within the app. Alternatively, use Ctrl+K/Cmd+K for prompting the command bar.",
   },

--- a/gui/src/components/Tour/Steps.tsx
+++ b/gui/src/components/Tour/Steps.tsx
@@ -1,0 +1,16 @@
+export const steps = [
+  {
+    selector: '[data-tour="step-1"]',
+    content: "Here you can quickly switch wallet, address and network.",
+  },
+  {
+    selector: '[data-tour="step-2"]',
+    content:
+      "Skip confirmation dialog when using a plaintext wallet on the anvil network",
+  },
+  {
+    selector: '[data-tour="step-3"]',
+    content:
+      "The main navigation tool within the app. Alternatively, use Ctrl+K/Cmd+K for prompting the command bar.",
+  },
+];

--- a/gui/src/components/Tour/Steps.tsx
+++ b/gui/src/components/Tour/Steps.tsx
@@ -1,4 +1,4 @@
-export const steps = [
+export const homepageSteps = [
   {
     selector: '[data-tour="step-1"]',
     content: "Here you can quickly switch wallet, address and network.",
@@ -6,7 +6,7 @@ export const steps = [
   {
     selector: '[data-tour="step-2"]',
     content:
-      "Skip confirmation dialog when using a plaintext wallet on the anvil network",
+      "Skip confirmation dialog when using a plaintext wallet on the anvil network.",
   },
   {
     selector: '[data-tour="step-3"]',

--- a/gui/src/components/Tour/index.tsx
+++ b/gui/src/components/Tour/index.tsx
@@ -27,6 +27,33 @@ export default function TourWrapper({ children, steps, onClose }: Props) {
       position="right"
       disableInteraction
       onClickClose={onClose}
+      onClickMask={({ setCurrentStep, currentStep, steps, setIsOpen }) => {
+        if (steps) {
+          if (currentStep === steps.length - 1) {
+            setIsOpen(false);
+            onClose();
+          } else {
+            setCurrentStep((s) => s + 1);
+          }
+        }
+      }}
+      keyboardHandler={(e, clickProps) => {
+        if (!clickProps || !clickProps.steps) return;
+
+        const { setCurrentStep, steps, currentStep, setIsOpen } = clickProps;
+        const lastStep = steps.length - 1;
+
+        if (e.key === "ArrowRight") {
+          setCurrentStep(Math.min(currentStep + 1, lastStep));
+        }
+        if (e.key === "ArrowLeft") {
+          setCurrentStep(Math.max(currentStep - 1, 0));
+        }
+        if (e.key === "Escape" && currentStep === lastStep) {
+          setIsOpen(false);
+          onClose();
+        }
+      }}
     >
       {children}
     </TourProvider>

--- a/gui/src/components/Tour/index.tsx
+++ b/gui/src/components/Tour/index.tsx
@@ -1,0 +1,51 @@
+import { StylesObj, TourProvider } from "@reactour/tour";
+
+import ContentComponent from "./Content";
+
+const styles = {
+  popover: (base: StylesObj) => ({
+    ...base,
+    color: "black",
+    padding: 0,
+  }),
+  maskArea: (base: StylesObj) => ({ ...base, rx: 5 }),
+  maskWrapper: (base: StylesObj) => ({ ...base, color: "#ffffff" }),
+  controls: (base: StylesObj) => ({ ...base, marginTop: 50 }),
+  close: (base: StylesObj) => ({ ...base, left: "auto", right: 8, top: 8 }),
+};
+
+const steps = [
+  {
+    selector: '[data-tour="step-1"]',
+    content: "Here you can quickly switch wallets, address and networks.",
+  },
+  {
+    selector: '[data-tour="step-2"]',
+    content:
+      "Skip confirmation dialog when using a plaintext wallet on the anvil network",
+  },
+  {
+    selector: '[data-tour="step-3"]',
+    content:
+      "The main navigation tool within the app. Alternatively, use Ctrl+K/Cmd+K for prompting the command bar.",
+  },
+];
+
+export default function TourWrapper({ children }: Props) {
+  return (
+    <TourProvider
+      steps={steps}
+      ContentComponent={ContentComponent}
+      styles={styles}
+      position="right"
+      disableInteraction
+      showBadge={false}
+    >
+      {children}
+    </TourProvider>
+  );
+}
+
+interface Props {
+  children: React.ReactNode;
+}

--- a/gui/src/components/Tour/index.tsx
+++ b/gui/src/components/Tour/index.tsx
@@ -1,11 +1,10 @@
-import { StylesObj, TourProvider } from "@reactour/tour";
+import { StepType, StylesObj, TourProvider } from "@reactour/tour";
 
 import { useTheme } from "@/store/theme";
 
 import ContentComponent from "./Content";
-import { steps } from "./Steps";
 
-export default function TourWrapper({ children }: Props) {
+export default function TourWrapper({ children, steps, onClose }: Props) {
   const { theme } = useTheme();
 
   const maskWrapperColor =
@@ -27,6 +26,7 @@ export default function TourWrapper({ children }: Props) {
       styles={styles}
       position="right"
       disableInteraction
+      onClickClose={onClose}
     >
       {children}
     </TourProvider>
@@ -35,4 +35,6 @@ export default function TourWrapper({ children }: Props) {
 
 interface Props {
   children: React.ReactNode;
+  steps: StepType[];
+  onClose: () => void;
 }

--- a/gui/src/components/Tour/index.tsx
+++ b/gui/src/components/Tour/index.tsx
@@ -2,7 +2,7 @@ import { StepType, StylesObj, TourProvider } from "@reactour/tour";
 
 import { useTheme } from "@/store/theme";
 
-import ContentComponent from "./Content";
+import PopoverContent from "./PopoverContent";
 
 export default function TourWrapper({ children, steps, onClose }: Props) {
   const { theme } = useTheme();
@@ -22,7 +22,7 @@ export default function TourWrapper({ children, steps, onClose }: Props) {
   return (
     <TourProvider
       steps={steps}
-      ContentComponent={ContentComponent}
+      ContentComponent={PopoverContent}
       styles={styles}
       position="right"
       disableInteraction

--- a/gui/src/components/Tour/index.tsx
+++ b/gui/src/components/Tour/index.tsx
@@ -1,37 +1,25 @@
 import { StylesObj, TourProvider } from "@reactour/tour";
 
+import { useTheme } from "@/store/theme";
+
 import ContentComponent from "./Content";
-
-const styles = {
-  popover: (base: StylesObj) => ({
-    ...base,
-    color: "black",
-    padding: 0,
-  }),
-  maskArea: (base: StylesObj) => ({ ...base, rx: 5 }),
-  maskWrapper: (base: StylesObj) => ({ ...base, color: "#ffffff" }),
-  controls: (base: StylesObj) => ({ ...base, marginTop: 50 }),
-  close: (base: StylesObj) => ({ ...base, left: "auto", right: 8, top: 8 }),
-};
-
-const steps = [
-  {
-    selector: '[data-tour="step-1"]',
-    content: "Here you can quickly switch wallets, address and networks.",
-  },
-  {
-    selector: '[data-tour="step-2"]',
-    content:
-      "Skip confirmation dialog when using a plaintext wallet on the anvil network",
-  },
-  {
-    selector: '[data-tour="step-3"]',
-    content:
-      "The main navigation tool within the app. Alternatively, use Ctrl+K/Cmd+K for prompting the command bar.",
-  },
-];
+import { steps } from "./Steps";
 
 export default function TourWrapper({ children }: Props) {
+  const { theme } = useTheme();
+
+  const maskWrapperColor =
+    theme.palette.mode === "dark" ? "#ffffff" : "#000000";
+
+  const styles = {
+    popover: (base: StylesObj) => ({
+      ...base,
+      padding: 0,
+      backgroundColor: theme.palette.background.default,
+    }),
+    maskWrapper: (base: StylesObj) => ({ ...base, color: maskWrapperColor }),
+  };
+
   return (
     <TourProvider
       steps={steps}
@@ -39,7 +27,6 @@ export default function TourWrapper({ children }: Props) {
       styles={styles}
       position="right"
       disableInteraction
-      showBadge={false}
     >
       {children}
     </TourProvider>

--- a/gui/src/types.ts
+++ b/gui/src/types.ts
@@ -214,6 +214,7 @@ export const generalSettingsSchema = z.object({
   etherscanApiKey: z.string().optional().nullable(),
   hideEmptyTokens: z.boolean(),
   onboarded: z.boolean(),
+  homepageTourCompleted: z.boolean(),
   fastMode: z.boolean(),
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,37 @@
   resolved "https://registry.yarnpkg.com/@reach/observe-rect/-/observe-rect-1.2.0.tgz#d7a6013b8aafcc64c778a0ccb83355a11204d3b2"
   integrity sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==
 
+"@reactour/mask@*":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@reactour/mask/-/mask-1.1.0.tgz#e327306585ee3510e80169a7fa811e9d0b9448bb"
+  integrity sha512-GkJMLuTs3vTsm4Ryq2uXcE4sMzRP1p4xSd6juSOMqbHa7IVD/UiLCLqJWHR9xGSQPbYhpZAZAORUG5cS0U5tBA==
+  dependencies:
+    "@reactour/utils" "*"
+
+"@reactour/popover@*":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@reactour/popover/-/popover-1.1.1.tgz#c9b05ee31b8677d874f1479d724204b936e1128f"
+  integrity sha512-BouulO0sXfmuHSPX8FwCYI0fMeT+VsWqk7UTao3NQcUC5H903ZeKOV2GYpwSJtRUQhsyNEu1Q8cEruGRf1SOXQ==
+  dependencies:
+    "@reactour/utils" "*"
+
+"@reactour/tour@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/@reactour/tour/-/tour-3.6.1.tgz#7537c8faa48546fe4e312f125113459b7a19fa13"
+  integrity sha512-vzmgbm4T7n5gh0cjc4Zi4G3K29dXQyEdi/o7ZYLpNcisJ0hwP5jNKH7BgckrHWEGldBxYSWl34tsRmHcyxporQ==
+  dependencies:
+    "@reactour/mask" "*"
+    "@reactour/popover" "*"
+    "@reactour/utils" "*"
+
+"@reactour/utils@*":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@reactour/utils/-/utils-0.5.0.tgz#8886872d78839187fd53399834a1b9688e98d754"
+  integrity sha512-yQs5Nm/Dg1xRM7d/S/UILBV5OInrTgrjGzgc81/RP5khqdO5KnpOaC46yF83kDtCalte8X3RCwp+F2YA509k1w==
+  dependencies:
+    "@rooks/use-mutation-observer" "^4.11.2"
+    resize-observer-polyfill "^1.5.1"
+
 "@rollup/plugin-inject@^5.0.3":
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-inject/-/plugin-inject-5.0.3.tgz#0783711efd93a9547d52971db73b2fb6140a67b1"
@@ -1445,6 +1476,11 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
+
+"@rooks/use-mutation-observer@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@rooks/use-mutation-observer/-/use-mutation-observer-4.11.2.tgz#a0466c4338e0a4487ea19253c86bcd427c29f4af"
+  integrity sha512-vpsdrZdr6TkB1zZJcHx+fR1YC/pHs2BaqcuYiEGjBVbwY5xcC49+h0hAUtQKHth3oJqXfIX/Ng8S7s5HFHdM/A==
 
 "@safe-global/safe-apps-provider@^0.17.1":
   version "0.17.1"
@@ -7896,6 +7932,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+resize-observer-polyfill@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-alpn@^1.2.0:
   version "1.2.1"


### PR DESCRIPTION
This PR adds a guided tour through some app features.

Why:
- To explain the purpose of some features we want to highlight;

How:
- Using [react-tours](https://www.react.tours/) ([github](https://github.com/elrumordelaluz/reactour/tree/main/packages/tour));

Preview:
<img width="1440" alt="Screenshot 2023-11-02 at 17 47 29 (2)" src="https://github.com/Subvisual-Academy/iron/assets/26972187/87a6990e-659c-4a25-98ce-d6030c491d69">
<img width="1440" alt="Screenshot 2023-11-02 at 17 47 32 (2)" src="https://github.com/Subvisual-Academy/iron/assets/26972187/2dd657d2-e09e-42a1-8afa-414da4b11318">
<img width="1440" alt="Screenshot 2023-11-02 at 17 47 34 (2)" src="https://github.com/Subvisual-Academy/iron/assets/26972187/31fdfa7d-ffff-4f5d-9fdc-8c8006be5ffe">

<img width="1440" alt="Screenshot 2023-11-02 at 17 48 29 (2)" src="https://github.com/Subvisual-Academy/iron/assets/26972187/66ca03b9-a8e5-49c4-b852-eb34d701d4b9">