### PR TITLE
Refactors signing logic (to accomodate ledgers)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "coins-ledger"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fa6094030951ce3efad50fdba0efe088a93ffe05ec58c2f47cc60d9e90c715d"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "cfg-if",
+ "futures",
+ "getrandom 0.2.10",
+ "hex",
+ "hidapi-rusb",
+ "js-sys",
+ "lazy_static",
+ "libc",
+ "log",
+ "matches",
+ "nix",
+ "serde",
+ "tap",
+ "thiserror",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,11 +2271,15 @@ dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
+ "coins-ledger",
  "const-hex",
  "elliptic-curve",
  "eth-keystore",
  "ethers-core",
+ "futures-executor",
+ "futures-util",
  "rand 0.8.5",
+ "semver 1.0.18",
  "sha2",
  "thiserror",
  "tracing",
@@ -3138,8 +3169,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3423,6 +3456,18 @@ name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hidapi-rusb"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9fc48be9eab25c28b413742b38b57b85c10b5efd2d47ef013f82335cbecc8e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "rusb",
+]
 
 [[package]]
 name = "hkdf"
@@ -4513,6 +4558,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libusb1-sys"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d0e2afce4245f2c9a418511e5af8718bcaf2fa408aefb259504d1a9cb25f27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4776,6 +4833,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
@@ -6261,6 +6319,16 @@ name = "ruint-macro"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
+name = "rusb"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45fff149b6033f25e825cbb7b2c625a11ee8e6dac09264d49beb125e39aa97bf"
+dependencies = [
+ "libc",
+ "libusb1-sys",
+]
 
 [[package]]
 name = "rust-argon2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ iron-exchange-rates = { path = "crates/exchange-rates" }
 
 tokio = { version = "1.33", features = ["full", "sync"] }
 thiserror = "1.0"
-ethers = { version = "2", features = ["ws"] }
+ethers = { version = "2", features = ["ws", "ledger"] }
 sqlx = { version = "0.7.2", features = [
   "runtime-tokio-rustls",
   "sqlite",

--- a/crates/forge/src/abi.rs
+++ b/crates/forge/src/abi.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
-use iron_types::Bytes;
 use std::{fs::File, io::BufReader, path::PathBuf, str::FromStr};
+
+use iron_types::Bytes;
 
 use super::{
     error::{Error, Result},

--- a/crates/rpc/src/error.rs
+++ b/crates/rpc/src/error.rs
@@ -1,7 +1,5 @@
 use ethers::{
-    core::k256::ecdsa::SigningKey,
     prelude::{signer::SignerMiddlewareError, *},
-    signers,
 };
 use iron_types::Address;
 use jsonrpc_core::ErrorCode;
@@ -21,7 +19,10 @@ pub enum Error {
     SignerBuild(String),
 
     #[error(transparent)]
-    SignerMiddleware(#[from] SignerMiddlewareError<Provider<Http>, signers::Wallet<SigningKey>>),
+    SignerMiddleware(#[from] SignerMiddlewareError<Provider<Http>, iron_wallets::Signer>),
+
+    #[error("Signer error: {0}")]
+    Signer(String),
 
     #[error(transparent)]
     Wallet(#[from] ethers::signers::WalletError),

--- a/crates/rpc/src/send_transaction.rs
+++ b/crates/rpc/src/send_transaction.rs
@@ -1,9 +1,7 @@
 use std::str::FromStr;
 
 use ethers::{
-    core::k256::ecdsa::SigningKey,
     prelude::*,
-    signers,
     types::{serde_helpers::StringifiedNumeric, transaction::eip2718::TypedTransaction},
 };
 use iron_connections::Ctx;
@@ -22,7 +20,7 @@ pub struct SendTransaction {
     pub wallet_name: String,
     pub wallet_path: String,
     pub request: TypedTransaction,
-    pub signer: Option<SignerMiddleware<Provider<Http>, signers::Wallet<SigningKey>>>,
+    pub signer: Option<SignerMiddleware<Provider<Http>, iron_wallets::Signer>>,
 }
 
 impl<'a> SendTransaction {
@@ -110,7 +108,7 @@ impl<'a> SendTransaction {
             let wallets = Wallets::read().await;
             let wallet = wallets.get(&self.wallet_name).unwrap();
 
-            let signer: signers::Wallet<SigningKey> = wallet
+            let signer = wallet
                 .build_signer(self.network.chain_id, &self.wallet_path)
                 .await
                 .unwrap();

--- a/crates/rpc/src/sign_message.rs
+++ b/crates/rpc/src/sign_message.rs
@@ -1,11 +1,9 @@
 use std::str::FromStr;
 
 use ethers::{
-    core::k256::ecdsa::SigningKey,
     prelude::SignerMiddleware,
     providers::{Http, Middleware as _, Provider},
-    signers,
-    signers::Signer,
+    signers::Signer as _,
     types::{transaction::eip712, Bytes, Signature},
 };
 use iron_dialogs::{Dialog, DialogMsg};
@@ -15,7 +13,7 @@ use serde::Serialize;
 
 use super::{Error, Result};
 
-type Middleware = SignerMiddleware<Provider<Http>, signers::Wallet<SigningKey>>;
+type Middleware = SignerMiddleware<Provider<Http>, iron_wallets::Signer>;
 
 /// Orchestrates message signing
 /// Takes references to both the wallet and network
@@ -65,12 +63,16 @@ impl<'a> SignMessage<'a> {
                 let bytes = Bytes::from_str(msg).unwrap();
                 Ok(signer.sign(bytes, &signer.address()).await?)
             }
-            Data::Typed(ref data) => Ok(signer.signer().sign_typed_data(&data.clone()).await?),
+            Data::Typed(ref data) => Ok(signer
+                .signer()
+                .sign_typed_data(&data.clone())
+                .await
+                .map_err(|e| Error::Signer(e.to_string()))?),
         }
     }
 
     async fn build_signer(&self) -> Middleware {
-        let signer: signers::Wallet<SigningKey> = self
+        let signer = self
             .wallet
             .build_signer(self.network.chain_id, &self.wallet_path)
             .await

--- a/crates/sync/anvil/src/expanders.rs
+++ b/crates/sync/anvil/src/expanders.rs
@@ -5,10 +5,9 @@ use ethers::{
     types::{Action, Call, Create, CreateResult, Log, Res, Trace},
 };
 use futures::future::join_all;
-use iron_types::ToAlloy;
 use iron_types::{
     events::{ContractDeployed, ERC20Transfer, ERC721Transfer, Tx},
-    Bytes, Event,
+    Bytes, Event, ToAlloy,
 };
 
 use super::{Error, Result};

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -3,13 +3,11 @@ pub mod events;
 mod global_state;
 mod tokens;
 pub mod ui_events;
-pub use foundry_utils::types::{ToAlloy, ToEthers};
-
 pub use affinity::Affinity;
 pub use alloy_primitives::{address, Address, B256, U256, U64};
-pub use ethers::abi::Abi;
-pub use ethers::types::Bytes;
+pub use ethers::{abi::Abi, types::Bytes};
 pub use events::Event;
+pub use foundry_utils::types::{ToAlloy, ToEthers};
 pub use global_state::GlobalState;
 pub use tokens::{
     Erc721Collection, Erc721Token, Erc721TokenData, Erc721TokenDetails, TokenBalance, TokenMetadata,

--- a/crates/wallets/src/commands.rs
+++ b/crates/wallets/src/commands.rs
@@ -53,9 +53,7 @@ pub async fn wallets_set_current_path(key: String) -> Result<()> {
 
 /// Get all known addresses of a wallet
 #[tauri::command]
-pub async fn wallets_get_wallet_addresses(
-    name: String,
-) -> Result<Vec<(String, Address)>> {
+pub async fn wallets_get_wallet_addresses(name: String) -> Result<Vec<(String, Address)>> {
     Ok(Wallets::read().await.get_wallet_addresses(name).await)
 }
 

--- a/crates/wallets/src/error.rs
+++ b/crates/wallets/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
 
     #[error(transparent)]
     ParseInto(#[from] std::num::ParseIntError),
+
+    #[error("Ledger error: {0}")]
+    Ledger(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -1,12 +1,10 @@
 pub mod commands;
 mod error;
-mod hd_wallet;
-mod impersonator;
 mod init;
-mod json_keystore_wallet;
-mod plaintext;
+mod signer;
 mod utils;
 mod wallet;
+mod wallets;
 
 use std::{
     collections::HashSet,
@@ -18,6 +16,7 @@ pub use error::{Error, Result};
 pub use init::init;
 use iron_types::{Address, Json, UINotify};
 use serde::Serialize;
+pub use signer::Signer;
 
 use self::wallet::WalletCreate;
 pub use self::wallet::{Wallet, WalletControl};
@@ -184,7 +183,7 @@ impl Wallets {
     fn ensure_current(&mut self) {
         if self.wallets.is_empty() {
             self.wallets
-                .push(Wallet::Plaintext(plaintext::PlaintextWallet::default()));
+                .push(Wallet::Plaintext(wallets::PlaintextWallet::default()));
         }
 
         if self.current >= self.wallets.len() {

--- a/crates/wallets/src/signer.rs
+++ b/crates/wallets/src/signer.rs
@@ -1,0 +1,77 @@
+use async_trait::async_trait;
+use ethers::types::{
+    transaction::{eip2718::TypedTransaction, eip712::Eip712},
+    Signature, H160,
+};
+
+use crate::{Error, Result};
+
+#[derive(Debug)]
+pub enum Signer {
+    SigningKey(ethers::signers::Wallet<ethers::core::k256::ecdsa::SigningKey>),
+    Ledger(ethers::signers::Ledger),
+}
+
+#[async_trait]
+impl ethers::signers::Signer for Signer {
+    type Error = crate::Error;
+
+    async fn sign_transaction(&self, message: &TypedTransaction) -> Result<Signature> {
+        match self {
+            Self::SigningKey(signer) => Ok(signer.sign_transaction(message).await?),
+            Self::Ledger(signer) => Ok(signer
+                .sign_transaction(message)
+                .await
+                .map_err(|e| Error::Ledger(e.to_string()))?),
+        }
+    }
+
+    async fn sign_message<S>(&self, message: S) -> Result<Signature>
+    where
+        S: AsRef<[u8]> + Send + Sync,
+    {
+        match self {
+            Self::SigningKey(signer) => Ok(signer.sign_message(message).await?),
+            Self::Ledger(signer) => Ok(signer
+                .sign_message(message)
+                .await
+                .map_err(|e| Error::Ledger(e.to_string()))?),
+        }
+    }
+
+    async fn sign_typed_data<T>(&self, payload: &T) -> Result<Signature>
+    where
+        T: Eip712 + Send + Sync,
+    {
+        match self {
+            Self::SigningKey(signer) => Ok(signer.sign_typed_data(payload).await?),
+            Self::Ledger(signer) => Ok(signer
+                .sign_typed_data(payload)
+                .await
+                .map_err(|e| Error::Ledger(e.to_string()))?),
+        }
+    }
+
+    fn address(&self) -> H160 {
+        match self {
+            Self::SigningKey(signer) => signer.address(),
+            Self::Ledger(signer) => signer.address(),
+        }
+    }
+    fn chain_id(&self) -> u64 {
+        match self {
+            Self::SigningKey(signer) => signer.chain_id(),
+            Self::Ledger(signer) => signer.chain_id(),
+        }
+    }
+
+    fn with_chain_id<T>(self, chain_id: T) -> Self
+    where
+        T: Into<u64>,
+    {
+        match self {
+            Self::SigningKey(signer) => Self::SigningKey(signer.with_chain_id(chain_id)),
+            Self::Ledger(signer) => Self::Ledger(signer.with_chain_id(chain_id)),
+        }
+    }
+}

--- a/crates/wallets/src/wallets/hd_wallet.rs
+++ b/crates/wallets/src/wallets/hd_wallet.rs
@@ -1,10 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
-use ethers::{
-    core::k256::ecdsa::SigningKey,
-    signers::{self, coins_bip39::English, MnemonicBuilder, Signer},
-};
+use ethers::signers::{coins_bip39::English, MnemonicBuilder, Signer as _};
 use iron_crypto::{self, EncryptedData};
 use iron_dialogs::{Dialog, DialogMsg};
 use iron_types::Address;
@@ -14,7 +11,8 @@ use tokio::{
     task::JoinHandle,
 };
 
-use super::{utils, wallet::WalletCreate, Error, Result, Wallet, WalletControl};
+use crate::Signer;
+use crate::{utils, wallet::WalletCreate, Error, Result, Wallet, WalletControl};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -99,7 +97,11 @@ impl WalletControl for HDWallet {
             .ok_or(Error::InvalidKey(path.into()))
     }
 
-    async fn build_signer(&self, chain_id: u32, path: &str) -> Result<signers::Wallet<SigningKey>> {
+    async fn get_all_addresses(&self) -> Vec<(String, Address)> {
+        self.addresses.clone()
+    }
+
+    async fn build_signer(&self, chain_id: u32, path: &str) -> Result<Signer> {
         if !self.addresses.iter().any(|(p, _)| p == path) {
             return Err(Error::InvalidKey(path.to_string()));
         }
@@ -115,11 +117,7 @@ impl WalletControl for HDWallet {
             .derivation_path(path)?
             .build()?;
 
-        Ok(signer.with_chain_id(chain_id))
-    }
-
-    async fn get_all_addresses(&self) -> Vec<(String, Address)> {
-        self.addresses.clone()
+        Ok(Signer::SigningKey(signer.with_chain_id(chain_id)))
     }
 }
 

--- a/crates/wallets/src/wallets/impersonator.rs
+++ b/crates/wallets/src/wallets/impersonator.rs
@@ -1,11 +1,14 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use ethers::core::k256::ecdsa::SigningKey;
+
 use iron_types::Address;
 use serde::{Deserialize, Serialize};
 
-use crate::{wallet::WalletCreate, Result, Wallet, WalletControl};
+use crate::{
+    wallet::{WalletCreate},
+    Result, Signer, Wallet, WalletControl,
+};
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct Impersonator {
@@ -69,11 +72,7 @@ impl WalletControl for Impersonator {
         Ok(self.addresses[usize::from_str(path)?])
     }
 
-    async fn build_signer(
-        &self,
-        _chain_id: u32,
-        _path: &str,
-    ) -> Result<ethers::signers::Wallet<SigningKey>> {
+    async fn build_signer(&self, _chain_id: u32, _path: &str) -> Result<Signer> {
         Err(crate::Error::WalletCantSign)
     }
 }

--- a/crates/wallets/src/wallets/mod.rs
+++ b/crates/wallets/src/wallets/mod.rs
@@ -1,0 +1,9 @@
+mod hd_wallet;
+mod impersonator;
+mod json_keystore_wallet;
+mod plaintext;
+
+pub use hd_wallet::HDWallet;
+pub use impersonator::Impersonator;
+pub use json_keystore_wallet::JsonKeystoreWallet;
+pub use plaintext::PlaintextWallet;

--- a/crates/wallets/src/wallets/plaintext.rs
+++ b/crates/wallets/src/wallets/plaintext.rs
@@ -2,14 +2,12 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use coins_bip32::path::DerivationPath;
-use ethers::{
-    core::k256::ecdsa::SigningKey,
-    signers::{coins_bip39::English, MnemonicBuilder, Signer},
-};
+use ethers::signers::{coins_bip39::English, MnemonicBuilder, Signer as _};
 use iron_types::{Address, ToAlloy};
 use serde::{Deserialize, Serialize};
 
-use super::{utils, wallet::WalletCreate, Result, Wallet, WalletControl};
+use crate::Signer;
+use crate::{utils, wallet::WalletCreate, Result, Wallet, WalletControl};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(try_from = "Deserializer", rename_all = "camelCase")]
@@ -39,7 +37,7 @@ impl WalletControl for PlaintextWallet {
     }
 
     async fn get_current_address(&self) -> Address {
-        self.build_current_signer(1)
+        self.build_signer(1, &self.current_path)
             .await
             .unwrap()
             .address()
@@ -66,24 +64,22 @@ impl WalletControl for PlaintextWallet {
         Ok(self.build_signer(1, path).await?.address().to_alloy())
     }
 
-    async fn build_signer(
-        &self,
-        chain_id: u32,
-        path: &str,
-    ) -> Result<ethers::signers::Wallet<SigningKey>> {
-        Ok(MnemonicBuilder::<English>::default()
-            .phrase(self.mnemonic.as_ref())
-            .derivation_path(path)?
-            .build()
-            .map(|v| v.with_chain_id(chain_id))?)
-    }
-
     async fn get_all_addresses(&self) -> Vec<(String, Address)> {
         utils::derive_addresses(&self.mnemonic, &self.derivation_path, self.count)
     }
 
     fn is_dev(&self) -> bool {
         true
+    }
+
+    async fn build_signer(&self, chain_id: u32, path: &str) -> Result<Signer> {
+        let signer = MnemonicBuilder::<English>::default()
+            .phrase(self.mnemonic.as_ref())
+            .derivation_path(path)?
+            .build()
+            .map(|v| v.with_chain_id(chain_id))?;
+
+        Ok(Signer::SigningKey(signer))
     }
 }
 

--- a/crates/ws/src/peers.rs
+++ b/crates/ws/src/peers.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::SocketAddr};
 
 use iron_networks::Networks;
-use iron_types::{Affinity, Address, GlobalState, UINotify};
+use iron_types::{Address, Affinity, GlobalState, UINotify};
 use serde::Serialize;
 use serde_json::json;
 use tokio::sync::mpsc;


### PR DESCRIPTION
The existing signing logic doesn't fit different `Signer` types. So far, all wallets are `ethers::signer::Wallet<SigningKey>`, which is a signer that holds a private key in memory somehow.

Ledgers will use `ethers::signer::Ledger` instead.

Since these traits are not object-safe, we can't box them. And due to restrictions with `enum_dispatch` we also can't make this whole setup a generic trait. Not to mention it would greatly increase the complexity

Instead, we now have our own `iron_wallet::Signer`, which does a similar forwarding to an `enum_dispatch`, to accomodate both SigningKeys and Ledgers