### PR TITLE
Dialog refactor

### DIFF
--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -64,7 +64,6 @@ impl IronApp {
                 iron_wallets::commands::wallets_ledger_derive,
                 iron_dialogs::commands::dialog_get_payload,
                 iron_dialogs::commands::dialog_send,
-                iron_dialogs::commands::dialog_finish,
                 iron_forge::commands::forge_get_abi,
                 iron_rpc::commands::rpc_send_transaction,
                 iron_connections::commands::connections_affinity_for,

--- a/crates/dialogs/src/commands.rs
+++ b/crates/dialogs/src/commands.rs
@@ -1,4 +1,4 @@
-use super::{error::Result, global::OPEN_DIALOGS, handle::DialogMsg};
+use super::{error::Result, global::OPEN_DIALOGS};
 
 /// Retrieves the payload for a dialog window
 /// Dialogs can call this once ready to retrieve the data they're meant to display
@@ -15,34 +15,7 @@ pub async fn dialog_send(id: u32, payload: serde_json::Value) -> Result<()> {
     let dialogs = OPEN_DIALOGS.lock().await;
     let dialog = dialogs.get(&id).unwrap();
 
-    let msg = DialogMsg::Data(payload);
-    dialog.incoming(msg).await?;
-
-    Ok(())
-}
-
-/// Receives the return value of a dialog, and closes it
-/// The dialog must return a Result<serde_json::Value>, indicating whether the result is a success
-/// or failure (e.g.: was the transaction approved or rejected?)
-///
-/// Since feature-gating doesn't play well inside the `generate_handler!` macro where this is
-/// called, we need to feature-gate inside the body
-#[tauri::command]
-pub async fn dialog_finish(
-    dialog: tauri::Window,
-    id: u32,
-    result: super::handle::DialogResult,
-) -> Result<()> {
-    dialog.close()?;
-
-    let mut dialogs = OPEN_DIALOGS.lock().await;
-    let dialog = dialogs.remove(&id).unwrap();
-
-    let msg = match result {
-        Ok(json) => DialogMsg::Accept(json),
-        Err(json) => DialogMsg::Reject(json),
-    };
-    dialog.incoming(msg).await.unwrap();
+    dialog.incoming(payload).await?;
 
     Ok(())
 }

--- a/crates/dialogs/src/error.rs
+++ b/crates/dialogs/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     Tauri(#[from] tauri::Error),
 
     #[error(transparent)]
-    Send(#[from] mpsc::error::SendError<super::handle::DialogMsg>),
+    Send(#[from] mpsc::error::SendError<iron_types::Json>),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/dialogs/src/global.rs
+++ b/crates/dialogs/src/global.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use once_cell::sync::Lazy;
 use tokio::sync::Mutex;
 
-type PendingDialogMap = HashMap<u32, super::handle::Dialog>;
+use crate::handle::DialogStore;
+
+type PendingDialogMap = HashMap<u32, DialogStore>;
 
 /// global map of pending dialogs
 pub(super) static OPEN_DIALOGS: Lazy<Mutex<PendingDialogMap>> = Lazy::new(Default::default);

--- a/crates/dialogs/src/handle.rs
+++ b/crates/dialogs/src/handle.rs
@@ -8,9 +8,12 @@ use tokio::sync::{mpsc, RwLock};
 
 use super::{global::OPEN_DIALOGS, presets, Result};
 
+/// A handle to a dialog
+/// The dialog will automatically close on Drop
 pub struct Dialog(Arc<RwLock<Inner>>);
 
-#[derive(Clone)]
+/// Structurally the same type as `Dialog`, but without `Drop` logic.
+/// This is the version of the Dialog that will be stored in the global map to be used by tauri
 pub struct DialogStore(Arc<RwLock<Inner>>);
 
 impl Dialog {

--- a/crates/dialogs/src/lib.rs
+++ b/crates/dialogs/src/lib.rs
@@ -5,4 +5,4 @@ mod handle;
 mod presets;
 
 pub use error::{Error, Result};
-pub use handle::{Dialog, DialogMsg};
+pub use handle::Dialog;

--- a/crates/rpc/src/send_transaction.rs
+++ b/crates/rpc/src/send_transaction.rs
@@ -5,7 +5,7 @@ use ethers::{
     types::{serde_helpers::StringifiedNumeric, transaction::eip2718::TypedTransaction},
 };
 use iron_connections::Ctx;
-use iron_dialogs::{Dialog, DialogMsg};
+use iron_dialogs::Dialog;
 use iron_networks::Network;
 use iron_settings::Settings;
 use iron_types::{Address, GlobalState, ToAlloy, ToEthers};
@@ -66,23 +66,14 @@ impl<'a> SendTransaction {
         dialog.open().await?;
 
         while let Some(msg) = dialog.recv().await {
-            match msg {
-                DialogMsg::Data(data) => match data.as_str() {
-                    Some("simulate") => self.simulate(&dialog).await?,
-                    Some("accept") => break,
-                    Some("reject") => {
-                        return Err(Error::TxDialogRejected);
-                    }
-                    _ => {
-                        return Err(Error::TxDialogRejected);
-                    }
-                },
-
-                DialogMsg::Accept(_response) => break,
-
+            match msg.as_str() {
+                Some("simulate") => self.simulate(&dialog).await?,
+                Some("accept") => break,
                 // TODO: what's the appropriate error to return here?
                 // or should we return Ok(_)? Err(_) seems too close the ws connection
-                _ => return Err(Error::TxDialogRejected),
+                _ => {
+                    return Err(Error::TxDialogRejected);
+                }
             }
         }
 

--- a/crates/rpc/src/sign_message.rs
+++ b/crates/rpc/src/sign_message.rs
@@ -6,7 +6,7 @@ use ethers::{
     signers::Signer as _,
     types::{transaction::eip712, Bytes, Signature},
 };
-use iron_dialogs::{Dialog, DialogMsg};
+use iron_dialogs::Dialog;
 use iron_networks::Network;
 use iron_wallets::{Wallet, WalletControl};
 use serde::Serialize;
@@ -43,15 +43,15 @@ impl<'a> SignMessage<'a> {
         let dialog = Dialog::new("msg-sign", params);
         dialog.open().await?;
 
-        match dialog.recv().await {
-            Some(DialogMsg::Accept(_)) => Ok(()),
-
-            _ =>
-            // TODO: what's the appropriate error to return here?
-            // or should we return Ok(_)? Err(_) seems to close the ws connection
-            {
-                Err(Error::TxDialogRejected)
+        if let Some(msg) = dialog.recv().await {
+            match msg.as_str() {
+                Some("accept") => Ok(()),
+                // TODO: what's the appropriate error to return here?
+                // or should we return Ok(_)? Err(_) seems to close the ws connection
+                _ => Err(Error::TxDialogRejected),
             }
+        } else {
+            Err(Error::TxDialogRejected)
         }
     }
 

--- a/crates/wallets/src/wallets/hd_wallet.rs
+++ b/crates/wallets/src/wallets/hd_wallet.rs
@@ -210,14 +210,12 @@ impl HDWallet {
             // if password was given, and correctly decrypts the keystore
             if let Ok(mnemonic) = iron_crypto::decrypt(&self.ciphertext, &password) {
                 self.store_secret(mnemonic).await;
-                dialog.close().await?;
                 return Ok(());
             }
 
             dialog.send("failed", None).await?;
         }
 
-        dialog.close().await?;
         Err(Error::UnlockDialogFailed)
     }
 

--- a/crates/wallets/src/wallets/json_keystore_wallet.rs
+++ b/crates/wallets/src/wallets/json_keystore_wallet.rs
@@ -122,14 +122,12 @@ impl JsonKeystoreWallet {
             // if password was given, and correctly decrypts the keystore
             if let Ok(keystore) = signers::Wallet::decrypt_keystore(self.file.clone(), password) {
                 self.store_secret(&keystore).await;
-                dialog.close().await?;
                 return Ok(());
             }
 
             dialog.send("failed", None).await?;
         }
 
-        dialog.close().await?;
         Err(Error::UnlockDialogFailed)
     }
 

--- a/crates/wallets/src/wallets/json_keystore_wallet.rs
+++ b/crates/wallets/src/wallets/json_keystore_wallet.rs
@@ -5,7 +5,7 @@ use ethers::{
     core::k256::ecdsa::SigningKey,
     signers::{self, Signer as _},
 };
-use iron_dialogs::{Dialog, DialogMsg};
+use iron_dialogs::Dialog;
 use iron_types::Address;
 use secrets::SecretVec;
 use tokio::{
@@ -108,15 +108,14 @@ impl JsonKeystoreWallet {
 
         // attempt to receive a password at most 3 times
         for _ in 0..3 {
-            let password = match dialog.recv().await {
-                Some(DialogMsg::Data(payload)) | Some(DialogMsg::Accept(payload)) => {
-                    let password = payload["password"].clone();
-                    password
-                        .as_str()
-                        .ok_or(Error::UnlockDialogRejected)?
-                        .to_string()
-                }
-                _ => return Err(Error::UnlockDialogRejected),
+            let password = if let Some(payload) = dialog.recv().await {
+                let password = payload["password"].clone();
+                password
+                    .as_str()
+                    .ok_or(Error::UnlockDialogRejected)?
+                    .to_string()
+            } else {
+                return Err(Error::UnlockDialogRejected);
             };
 
             // if password was given, and correctly decrypts the keystore

--- a/gui/src/components/Dialogs/MsgSign.tsx
+++ b/gui/src/components/Dialogs/MsgSign.tsx
@@ -5,7 +5,7 @@ import { useDialog } from "@/hooks";
 import { DialogLayout } from "./Layout";
 
 export function MsgSignDialog({ id }: { id: number }) {
-  const { data, accept, reject } = useDialog<Record<string, string>>(id);
+  const { data, send } = useDialog<Record<string, string>>(id);
 
   if (!data) return null;
 
@@ -19,10 +19,18 @@ export function MsgSignDialog({ id }: { id: number }) {
       <Typography>{msg}</Typography>
 
       <Stack direction="row" justifyContent="center" spacing={2}>
-        <Button variant="contained" color="error" onClick={() => reject()}>
+        <Button
+          variant="contained"
+          color="error"
+          onClick={() => send("reject")}
+        >
           Reject
         </Button>
-        <Button variant="contained" type="submit" onClick={() => accept(data)}>
+        <Button
+          variant="contained"
+          type="submit"
+          onClick={() => send("accept")}
+        >
           Sign
         </Button>
       </Stack>

--- a/gui/src/hooks/useDialog.ts
+++ b/gui/src/hooks/useDialog.ts
@@ -12,18 +12,18 @@ export function useDialog<T>(id: number) {
     [id],
   );
 
-  const accept = useCallback(
-    (payload: unknown = {}) =>
-      invoke("dialog_finish", { id, result: { Ok: payload } }),
-    [id],
-  );
+  // const accept = useCallback(
+  //   (payload: unknown = {}) =>
+  //     invoke("dialog_finish", { id, result: { Ok: payload } }),
+  //   [id],
+  // );
+  //
+  // const reject = useCallback(
+  //   (payload: unknown = {}) => {
+  //     invoke("dialog_finish", { id, result: { Err: payload } });
+  //   },
+  //   [id],
+  // );
 
-  const reject = useCallback(
-    (payload: unknown = {}) => {
-      invoke("dialog_finish", { id, result: { Err: payload } });
-    },
-    [id],
-  );
-
-  return { data, send, accept, reject, listen };
+  return { data, send, listen };
 }


### PR DESCRIPTION
Simplifies the dialog logic:
* no longer have an explicit accept/reject type. Instead, each dialog handles its own lifecycle with json messages as it sees fit (a simple `"accept"` message replaces the previous behaviour of `DialogMsg::Accept`.
* This is because the previous logic no longer had much use after the ledger integration was merged, since it increased complexity in the lifecycle of the TX review dialog