### PR TITLE
Fies a deadlock on SendTransaction

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -44,7 +44,7 @@ export default function App() {
       <CssBaseline>
         <ErrorHandler>
           <QueryClientProvider client={queryClient}>
-            <DevBuildNotice />
+            {/* <DevBuildNotice /> */}
             <WagmiWrapper>
               <Routes />
             </WagmiWrapper>


### PR DESCRIPTION
The `SendTransaction` logic would indefinitely lock on to `Wallets::read()` for the entire duration of the dialog, which means write operations on wallets would hang forever (e.g.: changing the current wallet on the main UI)

this issue would get even bigger when users close the dialog, which currently does not clean up the `SendTransaction` object (something to fix later, not as serious), since the deadlock would now be there forever