### PR TITLE
Ensure at most 1 iron instance is running

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3857,6 +3857,7 @@ dependencies = [
  "iron-types",
  "iron-wallets",
  "iron-ws",
+ "named-lock",
  "serde",
  "serde_json",
  "tauri",
@@ -4004,11 +4005,13 @@ dependencies = [
  "iron-types",
  "iron-wallets",
  "iron-ws",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -4773,6 +4776,20 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "named-lock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b4a84f3731e71a5792fca72324356bf700c8959d31a2ac34134b25989f254c3"
+dependencies = [
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "thiserror",
+ "widestring",
+ "winapi",
 ]
 
 [[package]]
@@ -8763,6 +8780,12 @@ name = "whoami"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+
+[[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
 
 [[package]]
 name = "winapi"

--- a/bin/iron/Cargo.toml
+++ b/bin/iron/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "016512b" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+named-lock = "0.3.0"
 
 [build-dependencies]
 tauri-build = { version = "1.2", features = [] }

--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -11,6 +11,7 @@ use tauri::{
 };
 use tauri_plugin_window_state::Builder as windowStatePlugin;
 
+use crate::utils::{main_window_hide, main_window_show};
 use crate::{commands, error::AppResult, menu};
 
 pub struct IronApp {
@@ -211,6 +212,9 @@ async fn event_listener(handle: AppHandle) {
                         .emit(&event_type, &payload)
                         .unwrap();
                 }
+
+                MainWindowShow => main_window_show(&handle),
+                MainWindowHide => main_window_hide(&handle),
             }
         }
     }
@@ -231,7 +235,7 @@ fn config_dir(_app: &tauri::App) -> PathBuf {
 }
 
 #[cfg(not(debug_assertions))]
-fn config_dir(_app: &tauri::App) -> PathBuf {
+fn config_dir(app: &tauri::App) -> PathBuf {
     app.path_resolver()
         .app_config_dir()
         .expect("failed to resolve app_config_dir")

--- a/bin/iron/src/error.rs
+++ b/bin/iron/src/error.rs
@@ -13,6 +13,9 @@ pub enum AppError {
     Forge(#[from] iron_forge::Error),
 
     #[error(transparent)]
+    Http(#[from] iron_http::Error),
+
+    #[error(transparent)]
     FixPathEnv(#[from] fix_path_env::Error),
 
     #[error(transparent)]
@@ -20,6 +23,9 @@ pub enum AppError {
 
     #[error(transparent)]
     Tracing(#[from] iron_tracing::TracingError),
+
+    #[error("App already running")]
+    NamedLock(#[from] named_lock::Error),
 }
 
 pub type AppResult<T> = std::result::Result<T, AppError>;

--- a/bin/iron/src/main.rs
+++ b/bin/iron/src/main.rs
@@ -7,11 +7,28 @@ mod error;
 mod menu;
 #[cfg(not(target_os = "macos"))]
 mod system_tray;
+mod utils;
 
 use error::AppResult;
+use named_lock::NamedLock;
+
+#[cfg(not(debug_assertions))]
+static LOCK_NAME: &str = "iron-wallet";
+#[cfg(debug_assertions)]
+static LOCK_NAME: &str = "iron-wallet-dev";
 
 #[tokio::main]
 async fn main() -> AppResult<()> {
+    let lock = NamedLock::create(LOCK_NAME)?;
+
+    let _guard = match lock.try_lock() {
+        Ok(g) => g,
+        Err(_) => {
+            iron_http::request_main_window_open().await?;
+            panic!("App already running");
+        }
+    };
+
     iron_tracing::init()?;
     fix_path_env::fix()?;
 

--- a/bin/iron/src/system_tray.rs
+++ b/bin/iron/src/system_tray.rs
@@ -1,5 +1,7 @@
 use tauri::{AppHandle, Manager, SystemTrayEvent};
 
+use crate::utils::main_window_show;
+
 pub(crate) fn build() -> tauri::SystemTray {
     use tauri::{CustomMenuItem, SystemTray, SystemTrayMenu, SystemTrayMenuItem};
 
@@ -22,20 +24,10 @@ pub(crate) fn event_handler(app: &AppHandle, event: SystemTrayEvent) {
         MenuItemClick { id, .. } => match id.as_str() {
             "quit" => app.exit(0),
             "hide" => app.get_window("main").unwrap().hide().unwrap(),
-            "show" => show_main_window(app),
+            "show" => main_window_show(app),
             _ => {}
         },
-        DoubleClick { .. } => show_main_window(app),
+        DoubleClick { .. } => main_window_show(app),
         _ => {}
-    }
-}
-
-fn show_main_window(app: &AppHandle) {
-    if let Some(w) = app.get_window("main") {
-        w.show().unwrap()
-    } else {
-        tauri::WindowBuilder::new(app, "main", tauri::WindowUrl::App("index.html".into()))
-            .build()
-            .unwrap();
     }
 }

--- a/bin/iron/src/utils.rs
+++ b/bin/iron/src/utils.rs
@@ -1,0 +1,15 @@
+use tauri::{AppHandle, Manager};
+
+pub(crate) fn main_window_show(app: &AppHandle) {
+    if let Some(w) = app.get_window("main") {
+        w.show().unwrap()
+    } else {
+        tauri::WindowBuilder::new(app, "main", tauri::WindowUrl::App("index.html".into()))
+            .build()
+            .unwrap();
+    }
+}
+
+pub(crate) fn main_window_hide(app: &AppHandle) {
+    app.get_window("main").map(|w| w.hide());
+}

--- a/crates/broadcast/src/lib.rs
+++ b/crates/broadcast/src/lib.rs
@@ -36,6 +36,9 @@ pub enum UIMsg {
 
     /// sends a new event to a dialog
     DialogSend(ui_events::DialogSend),
+
+    MainWindowShow,
+    MainWindowHide,
 }
 
 mod internal_msgs {
@@ -127,6 +130,14 @@ mod ui_msgs {
 
     pub async fn dialog_send(params: ui_events::DialogSend) {
         send(DialogSend(params)).await;
+    }
+
+    pub async fn main_window_show() {
+        send(MainWindowShow).await;
+    }
+
+    pub async fn main_window_hide() {
+        send(MainWindowHide).await;
     }
 
     /// broadcaster for UI msgs

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -27,6 +27,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
+reqwest = { workspace = true }
+tracing = { workspace = true }
 
 axum = "0.6"
 tower-http = { version = "0.4.4", features = ["cors", "trace"] }

--- a/crates/http/src/error.rs
+++ b/crates/http/src/error.rs
@@ -40,6 +40,9 @@ pub enum Error {
 
     #[error("invalid network")]
     InvalidNetwork,
+
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/http/src/init.rs
+++ b/crates/http/src/init.rs
@@ -30,6 +30,8 @@ pub async fn init(db: DB) {
             .layer(cors)
             .layer(TraceLayer::new_for_http());
 
+        tracing::debug!("HTTP server listening on: {}", addr);
+
         axum::Server::bind(&addr)
             .serve(app.into_make_service())
             .await

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -1,7 +1,10 @@
 mod error;
 mod init;
 mod routes;
+mod utils;
 
 pub use error::{Error, Result};
 pub use init::init;
 use init::Ctx;
+
+pub use utils::request_main_window_open;

--- a/crates/http/src/routes/mod.rs
+++ b/crates/http/src/routes/mod.rs
@@ -5,6 +5,7 @@ use crate::Ctx;
 mod contracts;
 mod rpc;
 mod transactions;
+mod ui;
 
 #[cfg(feature = "http-insecure-endpoints")]
 mod connections;
@@ -36,6 +37,7 @@ fn iron_routes() -> Router<Ctx> {
     Router::new()
         .nest("/transactions", transactions::router())
         .nest("/contracts", contracts::router())
+        .nest("/ui", ui::router())
 }
 
 #[cfg(feature = "http-insecure-endpoints")]
@@ -43,6 +45,7 @@ fn iron_routes() -> Router<Ctx> {
     Router::new()
         .nest("/connections", connections::router())
         .nest("/contracts", contracts::router())
+        .nest("/ui", ui::router())
         .nest("/db", db::router())
         .nest("/forge", forge::router())
         .nest("/settings", settings::router())

--- a/crates/http/src/routes/ui.rs
+++ b/crates/http/src/routes/ui.rs
@@ -1,0 +1,19 @@
+use axum::{routing::post, Router};
+
+use crate::{Ctx, Result};
+
+pub(super) fn router() -> Router<Ctx> {
+    Router::new()
+        .route("/show", post(show))
+        .route("/hide", post(hide))
+}
+
+pub(crate) async fn show() -> Result<()> {
+    iron_broadcast::main_window_show().await;
+    Ok(())
+}
+
+pub(crate) async fn hide() -> Result<()> {
+    iron_broadcast::main_window_hide().await;
+    Ok(())
+}

--- a/crates/http/src/utils.rs
+++ b/crates/http/src/utils.rs
@@ -1,0 +1,14 @@
+/// Request the main window to open on the current running Iron process.
+/// Used by the app to open the window of an existing process instead of instantiating a new one
+pub async fn request_main_window_open() -> crate::Result<()> {
+    let addr: String = std::env::var("IRON_HTTP_SERVER_ENDPOINT")
+        .unwrap_or("127.0.0.1:9003".into())
+        .parse()
+        .unwrap();
+
+    reqwest::Client::new()
+        .post(format!("http://{}/iron/ui/show", addr))
+        .send()
+        .await?;
+    Ok(())
+}

--- a/crates/ws/src/server.rs
+++ b/crates/ws/src/server.rs
@@ -20,7 +20,7 @@ pub(crate) async fn server_loop() {
     let addr = std::env::var("IRON_WS_SERVER_ENDPOINT").unwrap_or("127.0.0.1:9002".into());
     let listener = TcpListener::bind(&addr).await.expect("Can't listen to");
 
-    tracing::debug!("Listening on: {}", addr);
+    tracing::debug!("WS server listening on: {}", addr);
 
     while let Ok((stream, _)) = listener.accept().await {
         let peer = stream


### PR DESCRIPTION
If iron is started, and a global lock file is already created, the app
  won't start
instead, it will send an HTTP request to the running process asking for the main window to be open (in case it's currently hidden)

This mimics the behaviour of many modern desktop apps