### PR TITLE
Building extension after app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,45 +40,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # build extension
-  # upload to draft release
-  # release to mozilla and google stores
-  extension:
-    needs: [setup]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          cache: "yarn"
-          node-version-file: ".tool-versions"
-
-      - name: Install dependencies
-        run: yarn workspace @iron/extension install
-
-      - name: Create bundles
-        run: yarn workspace @iron/extension build
-
-      - name: Upload to release
-        run: gh release upload ${{ needs.setup.outputs.tag }} ./extension/dist/*.{crx,zip,xpi}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Submit to Google
-        run: npx chrome-webstore-upload-cli@2 upload --source ./extension/dist/chrome
-        env:
-          EXTENSION_ID: ${{ secrets.CHROME_WEB_EXT_ID }}
-          CLIENT_ID: ${{ secrets.CHROME_WEB_EXT_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CHROME_WEB_EXT_CLIENT_SECRET }}
-          REFRESH_TOKEN: ${{ secrets.CHROME_WEB_EXT_REFRESH_TOKEN }}
-
-      - name: Submit to Mozilla
-        run: npx web-ext-submit@7 --source-dir ./extension/dist/firefox
-        env:
-          WEB_EXT_API_KEY: ${{ secrets.FIREFOX_WEB_EXT_API_KEY }}
-          WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_WEB_EXT_API_SECRET }}
-
   # build app
   # upload to draft release
   app:
@@ -134,6 +95,45 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           releaseId: ${{ needs.setup.outputs.release_id }}
+
+  # build extension
+  # upload to draft release
+  # release to mozilla and google stores
+  extension:
+    needs: [setup, app]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          cache: "yarn"
+          node-version-file: ".tool-versions"
+
+      - name: Install dependencies
+        run: yarn workspace @iron/extension install
+
+      - name: Create bundles
+        run: yarn workspace @iron/extension build
+
+      - name: Upload to release
+        run: gh release upload ${{ needs.setup.outputs.tag }} ./extension/dist/*.{crx,zip,xpi}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Submit to Google
+        run: npx chrome-webstore-upload-cli@2 upload --source ./extension/dist/chrome
+        env:
+          EXTENSION_ID: ${{ secrets.CHROME_WEB_EXT_ID }}
+          CLIENT_ID: ${{ secrets.CHROME_WEB_EXT_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CHROME_WEB_EXT_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.CHROME_WEB_EXT_REFRESH_TOKEN }}
+
+      - name: Submit to Mozilla
+        run: npx web-ext-submit@7 --source-dir ./extension/dist/firefox
+        env:
+          WEB_EXT_API_KEY: ${{ secrets.FIREFOX_WEB_EXT_API_KEY }}
+          WEB_EXT_API_SECRET: ${{ secrets.FIREFOX_WEB_EXT_API_SECRET }}
 
   publish:
     needs: [setup, extension, app]


### PR DESCRIPTION
Since the extension release job publishes to chrome/firefox stores, and versions are no replaceable, we only want to do it once a release is successfully built, otherwise we risk having to artificially increment version number for a fix