### PR TITLE
Prevent leak of TAURI_ env variables

### DIFF
--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(() => ({
   },
   // to make use of `TAURI_DEBUG` and other env variables
   // https://tauri.studio/v1/api/config#buildconfig.beforedevcommand
-  envPrefix: ["VITE_", "TAURI_"],
+  envPrefix: ["VITE_"],
   build: {
     // Tauri supports es2021
     target: process.env.TAURI_PLATFORM == "windows" ? "chrome105" : "safari14",


### PR DESCRIPTION
While we are not vulnerable, since we don't use tauri's updater and have no private key generated, this is an important fix to apply

Fixes https://github.com/iron-wallet/iron/security/dependabot/34