### PR TITLE
Autostart on boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,11 +1759,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1763,6 +1783,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2291,7 +2322,7 @@ source = "git+https://github.com/gakonst/ethers-rs?rev=841ff8c47980798fbb47991e0
 dependencies = [
  "cfg-if",
  "const-hex",
- "dirs",
+ "dirs 5.0.1",
  "dunce",
  "ethers-core",
  "glob",
@@ -2626,7 +2657,7 @@ dependencies = [
  "alloy-primitives",
  "cfg-if",
  "const-hex",
- "dirs",
+ "dirs 5.0.1",
  "dunce",
  "futures-util",
  "glob",
@@ -3839,6 +3870,7 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 name = "iron"
 version = "1.1.1"
 dependencies = [
+ "auto-launch",
  "clap",
  "ethers",
  "fix-path-env",
@@ -4071,6 +4103,7 @@ name = "iron-settings"
 version = "1.1.1"
 dependencies = [
  "async-trait",
+ "auto-launch",
  "ethers",
  "iron-broadcast",
  "iron-types",
@@ -7423,7 +7456,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597e3a746727984cb7ea2487b6a40726cad0dbe86628e7d429aa6b8c4c153db4"
 dependencies = [
- "dirs",
+ "dirs 5.0.1",
  "fs2",
  "hex",
  "once_cell",
@@ -9111,6 +9144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/bin/iron/Cargo.toml
+++ b/bin/iron/Cargo.toml
@@ -39,6 +39,7 @@ clap = { workspace = true }
 fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs", rev = "016512b" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 named-lock = "0.3.0"
+auto-launch = "0.5.0"
 
 [build-dependencies]
 tauri-build = { version = "1.2", features = [] }

--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -119,7 +119,7 @@ async fn init(app: &tauri::App, args: &Args) -> AppResult<()> {
     // calls other crates' initialization logic. anvil needs to be started before networks,
     // otherwise the initial tracker won't be ready to spawn
     iron_sync::init(db.clone()).await;
-    iron_settings::init(resource(app, "settings.json")).await;
+    iron_settings::init(resource(app, "settings.json")).await?;
     iron_ws::init(args).await;
     iron_http::init(args, db).await;
     iron_connections::init(resource(app, "connections.json")).await;

--- a/bin/iron/src/commands.rs
+++ b/bin/iron/src/commands.rs
@@ -60,7 +60,9 @@ pub async fn get_contract_abi(
 
 #[tauri::command]
 pub async fn ui_error(message: String, _stack: Option<Vec<String>>) -> AppResult<()> {
-    tracing::error!(error_type = "UI Error", message = message, stack = _stack);
+    tracing::error!(error_type = "UI Error", message = message);
+
+    dbg!(_stack);
 
     Ok(())
 }

--- a/bin/iron/src/commands.rs
+++ b/bin/iron/src/commands.rs
@@ -60,7 +60,7 @@ pub async fn get_contract_abi(
 
 #[tauri::command]
 pub async fn ui_error(message: String, _stack: Option<Vec<String>>) -> AppResult<()> {
-    tracing::error!(error_type = "UI Error", message = message);
+    tracing::error!(error_type = "UI Error", message = message, stack = _stack);
 
     Ok(())
 }

--- a/bin/iron/src/commands.rs
+++ b/bin/iron/src/commands.rs
@@ -62,7 +62,5 @@ pub async fn get_contract_abi(
 pub async fn ui_error(message: String, _stack: Option<Vec<String>>) -> AppResult<()> {
     tracing::error!(error_type = "UI Error", message = message);
 
-    dbg!(_stack);
-
     Ok(())
 }

--- a/bin/iron/src/error.rs
+++ b/bin/iron/src/error.rs
@@ -24,6 +24,9 @@ pub enum AppError {
     #[error(transparent)]
     Tracing(#[from] iron_tracing::TracingError),
 
+    #[error(transparent)]
+    Settings(#[from] iron_settings::Error),
+
     #[error("App already running")]
     NamedLock(#[from] named_lock::Error),
 }

--- a/bin/iron/src/utils.rs
+++ b/bin/iron/src/utils.rs
@@ -21,6 +21,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
             .hidden_title(true);
 
         builder.build().unwrap();
+    }
 }
 
 pub(crate) fn main_window_hide(app: &AppHandle) {

--- a/bin/iron/src/utils.rs
+++ b/bin/iron/src/utils.rs
@@ -9,6 +9,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
         let app = app.clone();
         let onboarded = Settings::read().await.onboarded();
         let url = if onboarded { "/" } else { "/onboarding" };
+        dbg!(url);
 
         let builder = tauri::WindowBuilder::new(&app, "main", tauri::WindowUrl::App(url.into()))
             .fullscreen(false)
@@ -21,7 +22,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true);
 
-        builder.build().unwrap();
+        dbg!(builder.build()).unwrap();
     }
 }
 

--- a/bin/iron/src/utils.rs
+++ b/bin/iron/src/utils.rs
@@ -23,6 +23,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
             .hidden_title(true);
 
         builder.build().unwrap();
+        dbg!("built");
     }
 }
 

--- a/bin/iron/src/utils.rs
+++ b/bin/iron/src/utils.rs
@@ -22,7 +22,7 @@ pub(crate) async fn main_window_show(app: &AppHandle) {
             .title_bar_style(tauri::TitleBarStyle::Overlay)
             .hidden_title(true);
 
-        dbg!(builder.build()).unwrap();
+        builder.build().unwrap();
     }
 }
 

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -20,3 +20,4 @@ tokio = { workspace = true }
 thiserror = { workspace = true }
 once_cell = { workspace = true }
 async-trait = { workspace = true }
+auto-launch = "0.5.0"

--- a/crates/settings/src/autostart.rs
+++ b/crates/settings/src/autostart.rs
@@ -9,10 +9,8 @@ pub fn update(v: bool) -> Result<()> {
     }
 
     if v {
-        dbg!("enabling");
         handle.enable()?
     } else {
-        dbg!("disabling");
         handle.disable()?
     }
 

--- a/crates/settings/src/autostart.rs
+++ b/crates/settings/src/autostart.rs
@@ -1,0 +1,32 @@
+use crate::Result;
+use auto_launch::AutoLaunch;
+
+pub fn update(v: bool) -> Result<()> {
+    let handle = handle()?;
+
+    if handle.is_enabled()? == v {
+        return Ok(());
+    }
+
+    if v {
+        dbg!("enabling");
+        handle.enable()?
+    } else {
+        dbg!("disabling");
+        handle.disable()?
+    }
+
+    Ok(())
+}
+
+fn handle() -> Result<AutoLaunch> {
+    let app_name = "iron";
+    let app_path = std::env::current_exe()?
+        .into_os_string()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let args = &["--hidden"];
+
+    Ok(AutoLaunch::new(app_name, &app_path, args))
+}

--- a/crates/settings/src/autostart.rs
+++ b/crates/settings/src/autostart.rs
@@ -1,5 +1,5 @@
 use crate::Result;
-use auto_launch::AutoLaunch;
+use auto_launch::{AutoLaunch, AutoLaunchBuilder};
 
 pub fn update(v: bool) -> Result<()> {
     let handle = handle()?;
@@ -20,13 +20,16 @@ pub fn update(v: bool) -> Result<()> {
 }
 
 fn handle() -> Result<AutoLaunch> {
-    let app_name = "iron";
     let app_path = std::env::current_exe()?
         .into_os_string()
         .to_str()
         .unwrap()
         .to_owned();
-    let args = &["--hidden"];
 
-    Ok(AutoLaunch::new(app_name, &app_path, args))
+    Ok(AutoLaunchBuilder::new()
+        .set_app_name("iron")
+        .set_app_path(&app_path)
+        .set_use_launch_agent(true)
+        .set_args(&["--hidden"])
+        .build()?)
 }

--- a/crates/settings/src/error.rs
+++ b/crates/settings/src/error.rs
@@ -8,6 +8,9 @@ pub enum Error {
 
     #[error("Etherscan API key not set")]
     EtherscanKeyNotSet,
+
+    #[error(transparent)]
+    AutoLaunch(#[from] auto_launch::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/settings/src/init.rs
+++ b/crates/settings/src/init.rs
@@ -9,11 +9,11 @@ use iron_types::GlobalState;
 use once_cell::sync::OnceCell;
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use super::{SerializedSettings, Settings};
+use crate::{Result, SerializedSettings, Settings};
 
 static SETTINGS: OnceCell<RwLock<Settings>> = OnceCell::new();
 
-pub async fn init(pathbuf: PathBuf) {
+pub async fn init(pathbuf: PathBuf) -> Result<()> {
     let path = Path::new(&pathbuf);
 
     let res: Settings = if path.exists() {
@@ -33,7 +33,10 @@ pub async fn init(pathbuf: PathBuf) {
         }
     };
 
+    res.init().await?;
     SETTINGS.set(RwLock::new(res)).unwrap();
+
+    Ok(())
 }
 
 #[async_trait]

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -1,3 +1,4 @@
+mod autostart;
 pub mod commands;
 mod error;
 mod init;
@@ -33,6 +34,13 @@ pub enum DarkMode {
 }
 
 impl Settings {
+    pub async fn init(&self) -> Result<()> {
+        // make sure OS's autostart is synced with settings
+        crate::autostart::update(self.inner.autostart)?;
+
+        Ok(())
+    }
+
     pub async fn set(&mut self, params: serde_json::Map<String, serde_json::Value>) -> Result<()> {
         if let Some(v) = params.get("darkMode") {
             self.inner.dark_mode = serde_json::from_value(v.clone()).unwrap()
@@ -52,6 +60,11 @@ impl Settings {
 
         if let Some(v) = params.get("hideEmptyTokens") {
             self.inner.hide_empty_tokens = serde_json::from_value(v.clone()).unwrap()
+        }
+
+        if let Some(v) = params.get("autostart") {
+            self.inner.autostart = serde_json::from_value(v.clone()).unwrap();
+            crate::autostart::update(self.inner.autostart)?;
         }
 
         self.save().await?;
@@ -148,6 +161,9 @@ pub struct SerializedSettings {
 
     #[serde(default)]
     fast_mode: bool,
+
+    #[serde(default)]
+    autostart: bool,
 }
 
 impl Default for SerializedSettings {
@@ -161,6 +177,7 @@ impl Default for SerializedSettings {
             aliases: HashMap::new(),
             onboarded: false,
             fast_mode: false,
+            autostart: false,
         }
     }
 }

--- a/gui/src/components/Settings/General.tsx
+++ b/gui/src/components/Settings/General.tsx
@@ -21,6 +21,7 @@ import { useSettings } from "@/store";
 
 export const schema = z.object({
   darkMode: z.enum(["auto", "dark", "light"]),
+  autostart: z.boolean(),
   alchemyApiKey: z
     .string()
     .optional()
@@ -110,6 +111,27 @@ export function SettingsGeneral() {
               </Select>
             )}
           />
+        </FormControl>
+
+        <FormControl error={!!errors.autostart}>
+          <FormGroup>
+            <Controller
+              name="autostart"
+              control={control}
+              render={({ field }) => (
+                <FormControlLabel
+                  sx={{ pointerEvents: "auto" }}
+                  label="Start automatically on boot (minized)"
+                  control={<Switch {...field} checked={field.value} />}
+                />
+              )}
+            />
+          </FormGroup>
+          {errors.abiWatch && (
+            <FormHelperText>
+              {errors.abiWatch.message?.toString()}
+            </FormHelperText>
+          )}
         </FormControl>
 
         <FormControl error={!!errors.fastMode}>

--- a/gui/src/types/settings.ts
+++ b/gui/src/types/settings.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const generalSettingsSchema = z.object({
   darkMode: z.enum(["auto", "dark", "light"]),
+  autostart: z.boolean(),
   abiWatch: z.boolean(),
   abiWatchPath: z.string().optional().nullable(),
   alchemyApiKey: z.string().optional().nullable(),


### PR DESCRIPTION
Adds a new general setting, which toggles application autostart

this is supposed to be OS-agnostic, although I was only able to test it in linux & macos:
* linux: creates a ~/.config/autostart/iron.desktop`
* macos: creates a `~/Library/LaunchAgents/iron.plist`, and triggers a system notification about Iron being allowed as a background app