### PR TITLE
Fix typo on general settings

### DIFF
--- a/gui/src/components/Settings/General.tsx
+++ b/gui/src/components/Settings/General.tsx
@@ -121,7 +121,7 @@ export function SettingsGeneral() {
               render={({ field }) => (
                 <FormControlLabel
                   sx={{ pointerEvents: "auto" }}
-                  label="Start automatically on boot (minized)"
+                  label="Start automatically on boot (minimized)"
                   control={<Switch {...field} checked={field.value} />}
                 />
               )}


### PR DESCRIPTION
[
<img width="883" alt="Screenshot 2023-11-21 at 12 32 19" src="https://github.com/iron-wallet/iron/assets/26972187/ada23923-51fb-44e8-b095-434e076367bb">
](url)

Should be "minimized".