### PR TITLE
Fixing tauri-apps/tauri-action uploads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Miguel Palhas <mpalhas@gmail.com>"]
 
 [workspace]
 resolver = "2"
-members = ["bin/*", "crates/*"]
+members = ["bin/iron", "crates/*"]
 default-members = ["bin/iron"]
 
 [workspace.dependencies]


### PR DESCRIPTION
This was a weird one.
Releases today were failing, and took me way too long to figure out the root cause

This is the final output of a [failed build](https://github.com/iron-wallet/iron/actions/runs/7008385498/job/19064583451):

```
    Finished 2 bundles at:
        /home/runner/work/iron/iron/target/release/bundle/deb/iron_1.3.0_amd64.deb
        /home/runner/work/iron/iron/target/release/bundle/appimage/iron_1.3.0_amd64.AppImage

Looking for artifacts in:
/home/runner/work/iron/iron/bin/iron/target/release/bundle/deb/iron_1.3.0_amd64.deb
/home/runner/work/iron/iron/bin/iron/target/release/bundle/appimage/iron_1.3.0_amd64.AppImage
/home/runner/work/iron/iron/bin/iron/target/release/bundle/appimage/iron_1.3.0_amd64.AppImage.tar.gz
/home/runner/work/iron/iron/bin/iron/target/release/bundle/appimage/iron_1.3.0_amd64.AppImage.tar.gz.sig
```

notice that the bundle is being created at `./target/release`, but the tauri action is looking for artifacts in `./bin/iron/target/release`

`./bin/iron` is the crate in this workspace which compiles the binary

apparently the simple change in this PR (introduced initially when I was adding a 2nd binary, which ended up moving to a separate repo) had broken the action