### PR TITLE
extension: close runtime port on tab unload

### DIFF
--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -88,6 +88,10 @@ export function setupProviderConnection(port: Runtime.Port) {
     log.debug("[WS] request:", data);
     notifyDevtools(tabId, "request", data);
   });
+
+  port.onDisconnect.addListener(() => {
+    ws.close();
+  });
 }
 
 /**

--- a/extension/src/content-script/index.ts
+++ b/extension/src/content-script/index.ts
@@ -46,6 +46,10 @@ function initProviderForward() {
   // bg stream
   const bgPort = runtime.connect({ name: "iron:contentscript" });
 
+  window.onbeforeunload = () => {
+    bgPort.disconnect();
+  };
+
   // inpage -> bg
   inpageStream.on("data", (data) => {
     bgPort.postMessage(data);
@@ -54,9 +58,9 @@ function initProviderForward() {
   bgPort.onMessage.addListener((data) => {
     inpageStream.write(data);
   });
-  bgPort.onDisconnect.addListener(() =>
-    log.error("[Iron - contentscript] disconnected"),
-  );
+  bgPort.onDisconnect.addListener(() => {
+    log.warn("[Iron - contentscript] disconnected");
+  });
 }
 
 /**


### PR DESCRIPTION
This should greatly improve the UX, since extension connection was a bit finicky.
I belive it should help with the instances where we often need to reload the browser tab for the connection to be setup