### PR TITLE
feat: private key wallets

### DIFF
--- a/crates/simulator/tests/detris.rs
+++ b/crates/simulator/tests/detris.rs
@@ -20,7 +20,7 @@ async fn simulate_detris() {
 
     let mut evm = Evm::new(fork_url, fork_block_number, u64::MAX).await;
 
-    let res = dbg!(evm.call(tx).await).unwrap();
+    let res = evm.call(tx).await.unwrap();
 
     assert!(res.success);
     assert_eq!(res.gas_used, 118246);

--- a/crates/wallets/src/wallet.rs
+++ b/crates/wallets/src/wallet.rs
@@ -3,6 +3,8 @@ use enum_dispatch::enum_dispatch;
 use iron_types::{Address, Json};
 use serde::{Deserialize, Serialize};
 
+use crate::wallets::PrivateKeyWallet;
+
 use super::{
     wallets::{HDWallet, Impersonator, JsonKeystoreWallet, LedgerWallet, PlaintextWallet},
     Error, Result,
@@ -65,6 +67,8 @@ pub enum Wallet {
     Impersonator(Impersonator),
 
     Ledger(LedgerWallet),
+
+    PrivateKey(PrivateKeyWallet),
 }
 
 impl Wallet {
@@ -77,6 +81,7 @@ impl Wallet {
             "HDWallet" => HDWallet::create(params).await?,
             "impersonator" => Impersonator::create(params).await?,
             "ledger" => LedgerWallet::create(params).await?,
+            "privateKey" => PrivateKeyWallet::create(params).await?,
             _ => return Err(Error::InvalidWalletType(wallet_type.into())),
         };
 
@@ -91,6 +96,7 @@ pub enum WalletType {
     HDWallet,
     Impersonator,
     Ledger,
+    PrivateKey,
 }
 
 impl std::fmt::Display for WalletType {
@@ -104,6 +110,7 @@ impl std::fmt::Display for WalletType {
                 WalletType::HDWallet => "HDWallet",
                 WalletType::Impersonator => "impersonator",
                 WalletType::Ledger => "ledger",
+                WalletType::PrivateKey => "privateKey",
             }
         )
     }
@@ -117,6 +124,7 @@ impl From<&Wallet> for WalletType {
             Wallet::HDWallet(_) => Self::HDWallet,
             Wallet::Impersonator(_) => Self::Impersonator,
             Wallet::Ledger(_) => Self::Ledger,
+            Wallet::PrivateKey(_) => Self::PrivateKey,
         }
     }
 }

--- a/crates/wallets/src/wallets/mod.rs
+++ b/crates/wallets/src/wallets/mod.rs
@@ -3,9 +3,12 @@ mod impersonator;
 mod json_keystore_wallet;
 mod ledger;
 mod plaintext;
+mod private_key;
 
 pub use hd_wallet::HDWallet;
 pub use impersonator::Impersonator;
 pub use json_keystore_wallet::JsonKeystoreWallet;
 pub use ledger::LedgerWallet;
 pub use plaintext::PlaintextWallet;
+pub use private_key::PrivateKeyWallet;
+

--- a/crates/wallets/src/wallets/private_key.rs
+++ b/crates/wallets/src/wallets/private_key.rs
@@ -1,0 +1,192 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use coins_bip32::prelude::SigningKey;
+use ethers::signers;
+use ethers::signers::Signer as _;
+use iron_crypto::{self, EncryptedData};
+use iron_dialogs::{Dialog, DialogMsg};
+use iron_types::{Address, ToAlloy};
+use secrets::SecretVec;
+use tokio::{
+    sync::{Mutex, RwLock},
+    task::JoinHandle,
+};
+
+use crate::{wallet::WalletCreate, Error, Result, Signer, Wallet, WalletControl};
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateKeyWallet {
+    name: String,
+    address: Address,
+    ciphertext: EncryptedData<String>,
+
+    /// The signer is cached inside a `RwLock` so we can have interior mutability
+    /// Since JSON keystore signers are time-consuming to decrypt, we can't do it on-the-fly for
+    /// every incoming signing request
+    ///
+    /// The cache is stored as a
+    /// [SecretVec](https://docs.rs/secrets/latest/secrets/struct.SecretVec.html#method.new) for
+    /// some in-memory safety guarantees
+    ///
+    /// The additional Mutex within is there because `SecretVec` is not Send
+    #[serde(skip)]
+    secret: Arc<RwLock<Option<Mutex<SecretVec<u8>>>>>,
+
+    /// A join handle that will expire the signer after some time
+    #[serde(skip)]
+    expirer: Arc<RwLock<Option<JoinHandle<()>>>>,
+}
+
+#[async_trait]
+impl WalletCreate for PrivateKeyWallet {
+    async fn create(params: serde_json::Value) -> Result<Wallet> {
+        Ok(Wallet::PrivateKey(
+            Self::from_params(serde_json::from_value(params)?).await?,
+        ))
+    }
+}
+
+#[async_trait]
+impl WalletControl for PrivateKeyWallet {
+    fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    async fn update(mut self, params: serde_json::Value) -> Result<Wallet> {
+        if let Some(name) = params["name"].as_str() {
+            self.name = name.into();
+        }
+
+        Ok(Wallet::PrivateKey(self))
+    }
+
+    async fn get_current_address(&self) -> Address {
+        self.address
+    }
+
+    fn get_current_path(&self) -> String {
+        self.address.to_string()
+    }
+
+    async fn set_current_path(&mut self, _path: String) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_address(&self, _path: &str) -> Result<Address> {
+        Ok(self.get_current_address().await)
+    }
+
+    async fn get_all_addresses(&self) -> Vec<(String, Address)> {
+        vec![(self.get_current_path(), self.get_current_address().await)]
+    }
+
+    async fn build_signer(&self, chain_id: u32, _path: &str) -> Result<Signer> {
+        self.unlock().await?;
+
+        let secret = self.secret.read().await;
+        let secret = secret.as_ref().unwrap().lock().await;
+
+        let signer = signer_from_secret(&secret);
+        Ok(Signer::SigningKey(signer.with_chain_id(chain_id)))
+    }
+}
+
+impl PrivateKeyWallet {
+    pub async fn from_params(params: PrivateKeyWalletParams) -> Result<Self> {
+        let wallet: signers::Wallet<SigningKey> = params.private_key.clone().try_into().unwrap();
+
+        let ciphertext = iron_crypto::encrypt(&params.private_key, &params.password).unwrap();
+
+        Ok(Self {
+            name: params.name,
+            address: wallet.address().to_alloy(),
+            ciphertext,
+            secret: Default::default(),
+            expirer: Default::default(),
+        })
+    }
+
+    async fn is_unlocked(&self) -> bool {
+        let secret = self.secret.read().await;
+        secret.is_some()
+    }
+
+    async fn unlock(&self) -> Result<()> {
+        // if we already have a signer, then we're good
+        if self.is_unlocked().await {
+            return Ok(());
+        }
+
+        // open the dialog
+        let dialog = Dialog::new("wallet-unlock", serde_json::to_value(self).unwrap());
+        dialog.open().await?;
+
+        // attempt to receive a password at most 3 times
+        for _ in 0..3 {
+            let password = if let Some(DialogMsg::Data(payload)) = dialog.recv().await {
+                let password = payload["password"].clone();
+                password
+                    .as_str()
+                    .ok_or(Error::UnlockDialogRejected)?
+                    .to_string()
+            } else {
+                return Err(Error::UnlockDialogRejected);
+            };
+
+            // if password was given, and correctly decrypts the keystore
+            if let Ok(mnemonic) = iron_crypto::decrypt(&self.ciphertext, &password) {
+                self.store_secret(mnemonic).await;
+                return Ok(());
+            }
+
+            dialog.send("failed", None).await?;
+        }
+
+        Err(Error::UnlockDialogFailed)
+    }
+
+    async fn store_secret(&self, mnemonic: String) {
+        // acquire both write locks
+        let mut expirer_handle = self.expirer.write().await;
+        let mut secret_handle = self.secret.write().await;
+
+        let secret = mnemonic_into_secret(mnemonic);
+
+        *secret_handle = Some(Mutex::new(secret));
+
+        // set up cache expiration for 1 minute
+        let clone = Arc::clone(&self.secret);
+        *expirer_handle = Some(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            clone.write().await.take();
+        }));
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateKeyWalletParams {
+    private_key: String,
+    password: String,
+    name: String,
+}
+
+/// Converts a signer into a SecretVec
+pub fn mnemonic_into_secret(mnemonic: String) -> SecretVec<u8> {
+    let signer_bytes = mnemonic.into_bytes();
+    let bytes = signer_bytes.as_slice();
+
+    SecretVec::new(bytes.len(), |s| {
+        (0..bytes.len()).for_each(|i| {
+            s[i] = bytes[i];
+        });
+    })
+}
+
+/// Converts a SecretVec into a signer
+fn signer_from_secret(secret: &SecretVec<u8>) -> signers::Wallet<SigningKey> {
+    let signer_bytes = secret.borrow();
+    signers::Wallet::from_bytes(&signer_bytes).unwrap()
+}

--- a/gui/src/components/QuickAddressSelect.tsx
+++ b/gui/src/components/QuickAddressSelect.tsx
@@ -6,7 +6,7 @@ import {
   SelectChangeEvent,
 } from "@mui/material";
 import { map } from "lodash-es";
-import { Address } from "viem";
+import { Address, getAddress } from "viem";
 
 import { Wallet } from "@iron/types/wallets";
 import { useInvoke } from "@/hooks";
@@ -70,5 +70,8 @@ function getCurrentPath(wallet: Wallet, addresses: [string, Address][]) {
 
     case "ledger":
       return wallet.addresses[wallet.current || 0][0];
+
+    case "privateKey":
+      return getAddress(wallet.address);
   }
 }

--- a/gui/src/components/Settings/Wallet/PrivateKey.tsx
+++ b/gui/src/components/Settings/Wallet/PrivateKey.tsx
@@ -1,0 +1,256 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  Button,
+  Stack,
+  Step,
+  StepLabel,
+  Stepper,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import { FieldValues, useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { passwordFormSchema, passwordSchema } from "@iron/types/password";
+import { PrivateKeyWallet } from "@iron/types/wallets";
+
+export const schema = z.object({
+  name: z.string().min(1),
+  privateKey: z.string().regex(/^0x[a-fA-F0-9]{64}$/),
+  password: passwordSchema,
+});
+
+const createSchema = schema;
+
+const updateSchema = schema.pick({
+  name: true,
+});
+
+type CreateSchema = z.infer<typeof createSchema>;
+type UpdateSchema = z.infer<typeof updateSchema>;
+
+const steps = ["Import", "Secure"];
+
+interface Props {
+  wallet?: PrivateKeyWallet;
+
+  onSubmit: (data: CreateSchema | UpdateSchema) => void;
+  onRemove: () => void;
+}
+
+export function PrivateKeyForm({ wallet, ...props }: Props) {
+  if (!wallet) {
+    return <Create {...props} />;
+  } else {
+    return <Update wallet={wallet} {...props} />;
+  }
+}
+
+function Create({ onSubmit, onRemove }: Props) {
+  const [name, setName] = useState("");
+  const [step, setStep] = useState(0);
+  const [privateKey, setPrivateKey] = useState<string>("");
+  const [password, setPassword] = useState("");
+  const [submitted, setSubmitted] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!privateKey || !password || !name || submitted) return;
+    onSubmit({
+      name,
+      privateKey,
+      password,
+    });
+    setSubmitted(true);
+  }, [name, privateKey, password, onSubmit, submitted]);
+
+  return (
+    <Stack direction="column" spacing={2}>
+      <Stepper activeStep={step} alternativeLabel>
+        {steps.map((label) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      {step == 0 && (
+        <PrivateKeyStep
+          onSubmit={(name: string, privateKey) => {
+            setName(name);
+            setPrivateKey(privateKey);
+            setStep(1);
+          }}
+          onCancel={onRemove}
+        />
+      )}
+
+      {step == 1 && (
+        <PasswordStep
+          onSubmit={(p) => {
+            setPassword(p);
+            setStep(2);
+          }}
+          onCancel={onRemove}
+        />
+      )}
+    </Stack>
+  );
+}
+
+interface PrivateKeyStepProps {
+  onSubmit: (name: string, privateKey: string) => void;
+  onCancel: () => void;
+}
+
+function PrivateKeyStep({ onSubmit, onCancel }: PrivateKeyStepProps) {
+  const schema = createSchema.pick({ name: true, privateKey: true });
+  const {
+    handleSubmit,
+    reset,
+    register,
+    formState: { errors, isDirty, isValid },
+  } = useForm({
+    mode: "onChange",
+    resolver: zodResolver(schema),
+  });
+  const onSubmitInternal = (data: FieldValues) => {
+    onSubmit(data.name, data.privateKey);
+    reset(data);
+  };
+
+  return (
+    <Stack
+      direction="column"
+      spacing={2}
+      component="form"
+      onSubmit={handleSubmit(onSubmitInternal)}
+    >
+      <TextField
+        multiline
+        label="Name"
+        error={!!errors.name}
+        helperText={errors.name?.message?.toString()}
+        {...register("name")}
+      />
+      <Typography>Insert your 12-word privateKey</Typography>
+      <TextField
+        multiline
+        label="privateKey"
+        error={!!errors.privateKey}
+        helperText={errors.privateKey?.message?.toString()}
+        {...register("privateKey")}
+      />
+
+      <Stack direction="row" spacing={2} justifyContent="flex-end">
+        <Button color="warning" variant="contained" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          type="submit"
+          disabled={!isDirty || !isValid}
+        >
+          Continue
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+interface PasswordStepProps {
+  onSubmit: (privateKey: string) => void;
+  onCancel: () => void;
+}
+
+function PasswordStep({ onSubmit, onCancel }: PasswordStepProps) {
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isDirty, isValid },
+  } = useForm({
+    mode: "onChange",
+    resolver: zodResolver(passwordFormSchema),
+  });
+  const onSubmitInternal = (data: FieldValues) => {
+    onSubmit(data.password);
+  };
+
+  return (
+    <Stack
+      direction="column"
+      spacing={2}
+      component="form"
+      onSubmit={handleSubmit(onSubmitInternal)}
+    >
+      <Typography>Choose a secure password</Typography>
+      <TextField
+        type="password"
+        label="Password"
+        error={!!errors.password}
+        helperText={errors.password?.message?.toString()}
+        {...register("password")}
+      />
+      <TextField
+        type="password"
+        label="Password Confirmation"
+        error={!!errors.passwordConfirmation}
+        helperText={errors.passwordConfirmation?.message?.toString()}
+        {...register("passwordConfirmation")}
+      />
+
+      <Stack direction="row" spacing={2} justifyContent="flex-end">
+        <Button color="warning" variant="contained" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          type="submit"
+          disabled={!isDirty || !isValid}
+        >
+          Continue
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+function Update({ wallet, onSubmit, onRemove }: Props) {
+  const {
+    register,
+    handleSubmit,
+    formState: { isValid, isDirty, errors },
+  } = useForm({
+    mode: "onBlur",
+    resolver: zodResolver(updateSchema),
+    defaultValues: wallet,
+  });
+
+  return (
+    <Stack
+      spacing={2}
+      alignItems="flex-start"
+      component="form"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <TextField
+        label="Name"
+        error={!!errors.name}
+        helperText={errors.name?.message?.toString()}
+        {...register("name")}
+      />
+      <Stack direction="row" spacing={2}>
+        <Button
+          color="primary"
+          variant="contained"
+          type="submit"
+          disabled={!isDirty || !isValid}
+        >
+          Save
+        </Button>
+        <Button color="warning" variant="contained" onClick={onRemove}>
+          Remove
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/gui/src/components/Settings/Wallets.tsx
+++ b/gui/src/components/Settings/Wallets.tsx
@@ -20,6 +20,7 @@ import { ImpersonatorForm } from "./Wallet/Impersonator";
 import { JsonKeystore } from "./Wallet/JsonKeystore";
 import { Ledger } from "./Wallet/Ledger";
 import { Plaintext } from "./Wallet/Plaintext";
+import { PrivateKeyForm } from "./Wallet/PrivateKey";
 
 export function SettingsWallets() {
   const wallets = useWallets((s) => s.wallets);
@@ -82,6 +83,9 @@ function ExistingItem({ wallet }: ItemProps) {
         {wallet.type === "impersonator" && (
           <ImpersonatorForm wallet={wallet} {...props} />
         )}
+        {wallet.type === "privateKey" && (
+          <PrivateKeyForm wallet={wallet} {...props} />
+        )}
         {wallet.type === "ledger" && <Ledger wallet={wallet} {...props} />}
       </AccordionDetails>
     </Accordion>
@@ -115,6 +119,7 @@ function NewItem({ type, onFinish }: NewItemProps) {
       {type === "HDWallet" && <HDWalletForm {...props} />}
       {type === "impersonator" && <ImpersonatorForm {...props} />}
       {type === "ledger" && <Ledger {...props} />}
+      {type === "privateKey" && <PrivateKeyForm {...props} />}
     </Paper>
   );
 }

--- a/packages/types/wallets.ts
+++ b/packages/types/wallets.ts
@@ -64,6 +64,14 @@ export const jsonKeystoreSchema = z.object({
   currentPath: z.string().optional(),
 });
 
+export const privateKeySchema = z.object({
+  type: z.literal("privateKey"),
+  name: z.string().min(1),
+  address: addressSchema,
+  privateKey: z.string().regex(/^0x[a-fA-F0-9]{128}$/),
+  password: passwordSchema,
+});
+
 export const plaintextSchema = z.object({
   type: z.literal("plaintext"),
   name: z.string().min(1),
@@ -93,6 +101,7 @@ export const walletSchema = z.discriminatedUnion("type", [
   plaintextSchema,
   impersonatorSchema,
   ledgerSchema,
+  privateKeySchema,
 ]);
 
 export const walletTypes: Wallet["type"][] = Array.from(
@@ -107,3 +116,4 @@ export type JsonKeystoreWallet = z.infer<typeof jsonKeystoreSchema>;
 export type PlaintextWallet = z.infer<typeof plaintextSchema>;
 export type ImpersonatorWallet = z.infer<typeof impersonatorSchema>;
 export type LedgerWallet = z.infer<typeof ledgerSchema>;
+export type PrivateKeyWallet = z.infer<typeof privateKeySchema>;


### PR DESCRIPTION
Adds a new wallet type: raw private key.
This is the simplest of wallets, with a single key/address. Most of the logic is re-used from HDWallet (form flow for securely creating and encrypting a secret), but simplified since we don't need to even keep a list of addresses, and switching logic

The only reason this wasn't done before is because no one had asked yet. Now they did, at #564 

![image](https://github.com/iron-wallet/iron/assets/283819/4bf76692-ce62-4fe3-9ed5-295b0b9ae253)
