### PR TITLE
Using skeletons in tx view to fix reveal animation

### DIFF
--- a/gui/src/components/Datapoint.tsx
+++ b/gui/src/components/Datapoint.tsx
@@ -1,8 +1,8 @@
-import { Grid, Typography } from "@mui/material";
+import { Grid, Skeleton, Typography } from "@mui/material";
 
 interface DatapointProps {
   label: string;
-  value: React.ReactNode | string;
+  value?: React.ReactNode | string;
   short: boolean;
 }
 
@@ -12,7 +12,8 @@ export function Datapoint({ label, value, short }: DatapointProps) {
       <Typography color="gray" sx={{ fontSize: "12px" }}>
         {label}
       </Typography>
-      {value}
+      {value !== undefined && value}
+      {value === undefined && <Skeleton variant="text" width="80%" />}
     </Grid>
   );
 }

--- a/gui/src/components/Txs.tsx
+++ b/gui/src/components/Txs.tsx
@@ -147,8 +147,6 @@ function Details({ tx, chainId }: DetailsProps) {
   const { data: transaction } = useTransaction({ hash: tx.hash });
   const { data: receipt } = useWaitForTransaction({ hash: tx.hash });
 
-  if (!receipt || !transaction) return null;
-
   return (
     <Grid container rowSpacing={2}>
       <Datapoint label="hash" value={truncateEthAddress(tx.hash)} />
@@ -169,17 +167,19 @@ function Details({ tx, chainId }: DetailsProps) {
       <Datapoint
         label="data"
         value={
-          <CalldataView
-            data={transaction.input}
-            contract={tx.to}
-            chainId={chainId}
-          />
+          transaction && (
+            <CalldataView
+              data={transaction.input}
+              contract={tx.to}
+              chainId={chainId}
+            />
+          )
         }
       />
-      <Datapoint label="nonce" value={transaction.nonce} />
-      <Datapoint label="type" value={transaction.type} />
+      <Datapoint label="nonce" value={transaction?.nonce} />
+      <Datapoint label="type" value={transaction?.type} />
       {/* TODO: other txs types */}
-      {transaction.type == "eip1559" && (
+      {transaction?.type == "eip1559" && (
         <>
           <Datapoint
             label="maxFeePerGas"
@@ -195,12 +195,12 @@ function Details({ tx, chainId }: DetailsProps) {
       )}
       <Datapoint
         label="gasLimit"
-        value={`${formatGwei(transaction.gas)} gwei`}
+        value={transaction && `${formatGwei(transaction?.gas)} gwei`}
         short
       />
       <Datapoint
         label="gasUsed"
-        value={`${formatGwei(receipt.gasUsed)} gwei`}
+        value={receipt && `${formatGwei(receipt?.gasUsed)} gwei`}
         short
       />
     </Grid>


### PR DESCRIPTION
The transaction accordion reveal animation had a problem: since the content was only loaded on opening, the initial height of the details was much smaller than after the load (since the component would just be empty)
as a result, the animation would be much shorter, and with an immediate stutter right at the end, once loading is done

the new approach renders a skeleton for each datapoint instead of skipping the component