### PR TITLE
Fix Justfile dev command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,7 +13,7 @@ build:
   cargo build
 
 dev *args='':
-  cargo tauri dev --features ${IRON_FEATURES:-debug} -- -- -- $@
+  yarn tauri dev --features ${IRON_FEATURES:-debug} -- -- -- $@
 
 fix:
   cargo +nightly fmt --all


### PR DESCRIPTION
Why:
* The recent change to the way Tauri is installed and managed broke the
  Justfile dev command

How:
* Using `yarn tauri dev` instead of `cargo tauri dev` to run the `dev`
  command
