### PR TITLE
Using a data dir outside of target/debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tsconfig.tsbuildinfo
 target/
 !migrations/*.sql
 gui/vite.config.ts.timestamp-*
+dev-data
 
 # extension artifacts
 extension/*.zip

--- a/bin/iron/src/app.rs
+++ b/bin/iron/src/app.rs
@@ -189,7 +189,7 @@ fn resource(app: &tauri::App, resource: &str) -> PathBuf {
 
 #[cfg(debug_assertions)]
 fn config_dir(_app: &tauri::App) -> PathBuf {
-    PathBuf::from("../../target/debug/")
+    PathBuf::from("../../dev-data/default/")
 }
 
 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
This makes data more persistent even if we are to erase `target` and recompile the app
should solve the annoyance of having to re-sync and onboard constantly into the dev app