### PR TITLE
Revert "Show transaction status instead of successful transaction sub…

### DIFF
--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -245,15 +245,8 @@ impl Handler {
             .await;
 
         let result = sender.estimate_gas().await.finish().await?;
-        let hash = *result.tx_hash();
 
-        let receipt = result.get_receipt().await.unwrap();
-        let status = receipt.status();
-
-        Ok(json!({
-            "hash": format!("0x{:x}", hash),
-            "status": status,
-        }))
+        Ok(format!("0x{:x}", result.tx_hash()).into())
     }
 
     async fn send_call(params: serde_json::Value, ctx: Ctx) -> jsonrpc_core::Result<Bytes> {

--- a/gui/src/components/ContractCallForm.tsx
+++ b/gui/src/components/ContractCallForm.tsx
@@ -11,7 +11,7 @@ import debounce from "lodash-es/debounce";
 import { type FormEvent, useCallback, useEffect, useState } from "react";
 import { type Address, type Hash, decodeFunctionResult } from "viem";
 
-import type { Result, WriteResponse } from "@ethui/types";
+import type { Result } from "@ethui/types";
 import {
   Alert,
   AlertDescription,
@@ -150,21 +150,8 @@ function AbiItemFormWithSubmit({
           const result = await invoke<Hash>("rpc_eth_call", { params });
           setResult({ ok: true, value: { read: result } });
         } else {
-          const result = await invoke<WriteResponse>("rpc_send_transaction", {
-            params,
-          });
-
-          if (result.status && result.hash) {
-            setResult({ ok: true, value: { read: result.hash } });
-          }
-
-          if (!result.status && result.hash) {
-            setResult({ ok: false, error: "transaction reverted" });
-          }
-
-          if (!result.status && !result.hash) {
-            setResult({ ok: false, error: "failed to send transaction" });
-          }
+          const result = await invoke<Hash>("rpc_send_transaction", { params });
+          setResult({ ok: true, value: { write: result } });
         }
       } catch (_err) {
         setLoading(false);

--- a/gui/src/routes/home/_l/transactions.tsx
+++ b/gui/src/routes/home/_l/transactions.tsx
@@ -11,7 +11,7 @@ import * as tauriClipboard from "@tauri-apps/plugin-clipboard-manager";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { type Abi, type Address, formatEther, formatGwei } from "viem";
 
-import type { PaginatedTx, Tx, WriteResponse } from "@ethui/types";
+import type { PaginatedTx, Tx } from "@ethui/types";
 import { BlockNumber } from "@ethui/ui/components/block-number";
 import {
   Accordion,
@@ -293,7 +293,7 @@ function Details({ tx, chainId }: DetailsProps) {
 }
 
 function resend({ from, to, value, data }: Tx) {
-  invoke<WriteResponse>("rpc_send_transaction", {
+  invoke<string>("rpc_send_transaction", {
     params: { from, to, value, data },
   });
 }

--- a/gui/src/routes/home/_l/transfer/_l.erc20.tsx
+++ b/gui/src/routes/home/_l/transfer/_l.erc20.tsx
@@ -23,7 +23,7 @@ import { useBalances } from "#/store/useBalances";
 import { useNetworks } from "#/store/useNetworks";
 import { useWallets } from "#/store/useWallets";
 
-import type { Result, WriteResponse } from "@ethui/types";
+import type { Result } from "@ethui/types";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { Terminal } from "lucide-react";
 import type { Token } from "./-common";
@@ -128,24 +128,13 @@ function RouteComponent() {
 
   const onSubmit = async (data: Schema) => {
     try {
-      const result = await transferERC20(
+      const hash = await transferERC20(
         address,
         data.to as Address,
         data.value,
         currentToken.contract,
       );
-
-      if (result.status && result.hash) {
-        setResult({ ok: true, value: result.hash });
-      }
-
-      if (!result.status && result.hash) {
-        setResult({ ok: false, error: "transaction reverted" });
-      }
-
-      if (!result.status && !result.hash) {
-        setResult({ ok: false, error: "failed to send transaction" });
-      }
+      setResult({ ok: true, value: hash });
     } catch (e: any) {
       setResult({ ok: false, error: e.toString() });
     }
@@ -206,7 +195,7 @@ const transferERC20 = async (
     args: [to, value],
   });
 
-  return await invoke<WriteResponse>("rpc_send_transaction", {
+  return await invoke<`0x${string}`>("rpc_send_transaction", {
     params: {
       from,
       to: contract,

--- a/gui/src/routes/home/_l/transfer/_l.eth.tsx
+++ b/gui/src/routes/home/_l/transfer/_l.eth.tsx
@@ -17,7 +17,6 @@ import { useBalances } from "#/store/useBalances";
 import { useNetworks } from "#/store/useNetworks";
 import { useWallets } from "#/store/useWallets";
 
-import type { WriteResponse } from "@ethui/types";
 import { Terminal } from "lucide-react";
 import type { Token } from "./-common";
 
@@ -113,11 +112,8 @@ function RouteComponent() {
   if (!network || !address || !currentToken) return null;
 
   const onSubmit = async (data: FieldValues) => {
-    const result = await transferETH(address, data.to, data.value);
-
-    if (result.status && result.hash) {
-      setResult(result.hash);
-    }
+    const hash = await transferETH(address, data.to, data.value);
+    setResult(hash);
   };
 
   return (
@@ -151,7 +147,7 @@ function RouteComponent() {
 }
 
 const transferETH = async (from: Address, to: Address, value: bigint) => {
-  return await invoke<WriteResponse>("rpc_send_transaction", {
+  return await invoke<`0x${string}`>("rpc_send_transaction", {
     params: {
       from,
       to,

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1,4 +1,4 @@
-import type { Address, Hash } from "viem";
+import type { Address } from "viem";
 
 export interface Token {
   contract: Address;
@@ -115,8 +115,3 @@ export type Affinity = { sticky: DedupChainId } | "global" | "unset";
 export type Result<T, E = Error> =
   | { ok: true; value: T }
   | { ok: false; error: E };
-
-export type WriteResponse = {
-  status: boolean;
-  hash: Hash;
-};


### PR DESCRIPTION
I missed this during the initial review

@DavideSilva you edited an RPC endpoint's return value. but those have a specific spec. we can't just arbitrarily change their return value for the app's purposes. viem/wagmi and other clients will stop working

reverting the full PR here. The UI will need additional logic to figure out the transaction result