### PR TITLE
Better lock handling on ethui_networks

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 use ethui_args::Args;
 use ethui_broadcast::UIMsg;
 use named_lock::NamedLock;
-use tauri::{AppHandle, Builder, Emitter as _, Manager as _, Runtime, plugin::TauriPlugin};
+use tauri::{AppHandle, Builder, Emitter as _, Manager as _};
+#[cfg(feature = "aptabase")]
+use tauri::{Runtime, plugin::TauriPlugin};
 #[cfg(feature = "aptabase")]
 use tauri_plugin_aptabase::EventTracker;
 

--- a/bin/src/commands.rs
+++ b/bin/src/commands.rs
@@ -6,7 +6,7 @@ use ethui_db::{
 };
 use ethui_forge::GetAbiFor;
 use ethui_proxy_detect::ProxyType;
-use ethui_types::{Address, GlobalState, TauriResult, UINotify};
+use ethui_types::{Address, TauriResult, UINotify};
 use serde::Serialize;
 
 #[derive(Serialize)]
@@ -44,11 +44,7 @@ pub async fn add_contract(
     address: Address,
     db: tauri::State<'_, Db>,
 ) -> TauriResult<()> {
-    let networks = ethui_networks::Networks::read().await;
-
-    let network = networks
-        .get_network(chain_id as u32)
-        .wrap_err_with(|| format!("Invalid network {chain_id}"))?;
+    let network = ethui_networks::get_network(chain_id as u32).await?;
     let provider = network.get_alloy_provider().await?;
 
     let code = provider

--- a/crates/forge/src/utils.rs
+++ b/crates/forge/src/utils.rs
@@ -1,7 +1,6 @@
 use alloy::{primitives::Bytes, providers::Provider as _};
-use ethui_networks::Networks;
-use ethui_types::{Address, GlobalState, eyre};
-use tracing::{debug, error};
+use ethui_types::{Address, eyre};
+use tracing::debug;
 
 pub static FUZZ_DIFF_THRESHOLD: f64 = 0.2;
 
@@ -57,17 +56,8 @@ pub async fn get_code(chain_id: u32, address: Address) -> color_eyre::Result<Byt
         "no code in db. fetching from provider for address 0x{:x}",
         address
     );
-    let networks = Networks::read().await;
-    // instead of failing we should just skip
-    let network = match networks.get_network(chain_id) {
-        Some(network) => network,
-        None => {
-            error!("failed to get network for chain id {}. ignoring", chain_id);
-            return Err(eyre!("Invalid chain ID: {}", chain_id));
-        }
-    };
 
-    let provider = network.get_alloy_provider().await?;
+    let provider = ethui_networks::get_provider(chain_id).await?;
     provider
         .get_code_at(address)
         .await

--- a/crates/rpc/src/utils.rs
+++ b/crates/rpc/src/utils.rs
@@ -2,15 +2,9 @@ use alloy::providers::Provider as _;
 use ethui_types::prelude::*;
 
 pub async fn get_code(address: Address, chain_id: u32) -> color_eyre::Result<Option<Bytes>> {
-    use ethui_networks::Networks;
-    
-    let networks = Networks::read().await;
-    let network = networks.get_network(chain_id)
-        .ok_or_else(|| color_eyre::eyre::eyre!("Network with chain_id {} not found", chain_id))?;
-    let provider = network.get_provider();
-    
+    let provider = ethui_networks::get_provider(chain_id).await?;
     let code = provider.get_code_at(address).await?;
-    
+
     if code.is_empty() {
         Ok(None)
     } else {

--- a/crates/sync/src/commands.rs
+++ b/crates/sync/src/commands.rs
@@ -1,7 +1,5 @@
-use color_eyre::eyre::ContextCompat as _;
 use ethui_db::Db;
-use ethui_networks::Networks;
-use ethui_types::{Address, GlobalState, TauriResult, U256};
+use ethui_types::{Address, TauriResult, U256};
 
 #[tauri::command]
 pub async fn sync_alchemy_is_network_supported(chain_id: u32) -> bool {
@@ -19,11 +17,7 @@ pub async fn sync_get_native_balance(
         address: Address,
         db: tauri::State<'_, Db>,
     ) -> color_eyre::Result<U256> {
-        let network = Networks::read()
-            .await
-            .get_network(chain_id)
-            .cloned()
-            .with_context(|| format!("Invalid network: {chain_id}"))?;
+        let network = ethui_networks::get_network(chain_id).await?;
 
         // TODO: check with networks if this is anvil or not
         if network.is_dev().await {

--- a/crates/sync/src/utils.rs
+++ b/crates/sync/src/utils.rs
@@ -1,13 +1,13 @@
 use alloy::{
     consensus::{Transaction as _, TxType},
-    network::{Ethereum, TransactionResponse as _},
-    providers::{Provider as _, RootProvider},
+    network::TransactionResponse as _,
+    providers::Provider as _,
 };
 use ethui_abis::IERC20;
 use ethui_types::{TokenMetadata, events::Tx, prelude::*};
 
 pub(crate) async fn fetch_full_tx(chain_id: u32, hash: B256) -> color_eyre::Result<()> {
-    let provider = provider(chain_id).await?;
+    let provider = ethui_networks::get_provider(chain_id).await?;
 
     let tx = provider.get_transaction_by_hash(hash).await?;
     let receipt = provider.get_transaction_receipt(hash).await?;
@@ -49,7 +49,7 @@ pub(crate) async fn fetch_erc20_metadata(
     chain_id: u32,
     address: Address,
 ) -> color_eyre::Result<()> {
-    let provider = provider(chain_id).await?;
+    let provider = ethui_networks::get_provider(chain_id).await?;
 
     let contract = IERC20::new(address, provider);
 
@@ -66,13 +66,4 @@ pub(crate) async fn fetch_erc20_metadata(
         .unwrap();
 
     Ok(())
-}
-
-async fn provider(chain_id: u32) -> color_eyre::Result<RootProvider<Ethereum>> {
-    let networks = ethui_networks::Networks::read().await;
-
-    match networks.get_network(chain_id) {
-        Some(network) => Ok(network.get_alloy_provider().await?),
-        _ => Err(eyre!("Invalid network: {}", chain_id)),
-    }
 }

--- a/crates/types/src/prelude.rs
+++ b/crates/types/src/prelude.rs
@@ -5,7 +5,11 @@ pub use std::{
     sync::Arc,
 };
 
-pub use alloy::primitives::{Address, B256, Bytes, U64, U256, address};
+pub use alloy::{
+    network::Ethereum,
+    primitives::{Address, B256, Bytes, U64, U256, address},
+    providers::RootProvider,
+};
 pub use color_eyre::eyre::{Context as _, ContextCompat as _, Result, WrapErr, eyre};
 pub use serde::{Deserialize, Serialize};
 pub use serde_json::{Value as Json, json};

--- a/crates/ws/src/peers.rs
+++ b/crates/ws/src/peers.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use ethui_networks::Networks;
-use ethui_types::{prelude::*, Affinity, NetworkId};
+use ethui_types::{Affinity, NetworkId, prelude::*};
 use serde_json::json;
 use tokio::sync::mpsc;
 
@@ -98,7 +98,9 @@ impl Peers {
     ) {
         let chain_id = id.chain_id();
 
-        if Networks::read().await.validate_chain_id(chain_id) {
+        let is_valid = Networks::read().await.validate_chain_id(chain_id);
+
+        if is_valid {
             let msg = json!({
                 "method": "chainChanged",
                 "params": {


### PR DESCRIPTION
I identified a few places where locks on `ethui_networks::Networks` were being held for too long (during network requests) which is the likely cause of some UI hang-ups in recent versions

The new approach avoids locking into the global networks object by cloning the network itself, or fetching a provider directly in an auxiliary function

in a future update, we'll likely migrate this to kameo as well to ensure this kind of bug can't happen so easily