### PR TITLE
nix: fix dev shell linking (zlib + pkg-config wiring)

### DIFF
--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -5,6 +5,7 @@
 let
   buildInputs = with pkgs; [
     openssl
+    zlib
     webkitgtk_4_1
     gtk3
     cairo
@@ -12,11 +13,14 @@ let
     glib
     dbus
     libsoup_3
-    pkg-config
     at-spi2-atk
     atkmm
-    gobject-introspection
     harfbuzz
+  ];
+
+  nativeBuildInputs = with pkgs; [
+    pkg-config
+    gobject-introspection
   ];
 
   libraries = with pkgs; [
@@ -30,7 +34,7 @@ let
   ];
 in
 pkgs.mkShell {
-  inherit buildInputs;
+  inherit buildInputs nativeBuildInputs;
 
   shellHook = ''
     export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,6 +38,7 @@ in
 
     buildInputs = with pkgs; [
       openssl
+      zlib
       webkitgtk_4_1
       gtk3
       cairo


### PR DESCRIPTION
## Problem

`pnpm app:dev` (and cargo builds generally) failed to link inside the nix dev shell, in two stages:

1. **`mold: fatal: library not found: z`** — native crates (`libsqlite3-sys`, `libsodium-sys`, `ring`) emit `-lz`, but `zlib` was not on the linker search path.
2. **`The PKG_CONFIG_PATH environment variable is not set`** — every gtk crate (`glib-sys`, `gio-sys`, `gdk-sys`, …) failed because `pkg-config` lived in `buildInputs`, so its setup hook never populated `PKG_CONFIG_PATH` for the native build.

## Fix

- Add `zlib` to `buildInputs` in both `nix/devshell.nix` and `nix/package.nix`.
- Move `pkg-config` and `gobject-introspection` from `buildInputs` to a new `nativeBuildInputs` set in `nix/devshell.nix`, matching how `nix/package.nix` already wires pkg-config.

## Testing

Verified in a fresh `nix develop` that `PKG_CONFIG_PATH` is populated and `pkg-config` resolves `glib-2.0`, `gtk`, and `zlib`; `pnpm app:dev` then builds and links past the previously failing crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)