### PR TITLE
Implement `Anvil` snapshot/revert support

### DIFF
--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -86,6 +86,8 @@ impl EthUIApp {
                 ethui_networks::commands::networks_is_dev,
                 ethui_networks::commands::networks_anvil_snapshot,
                 ethui_networks::commands::networks_anvil_revert,
+                ethui_networks::commands::networks_anvil_delete_snapshot,
+                ethui_networks::commands::networks_anvil_reset,
                 ethui_networks::commands::networks_chain_id_from_provider,
                 ethui_db::commands::db_get_contracts,
                 ethui_db::commands::db_get_newer_transactions,

--- a/bin/src/app.rs
+++ b/bin/src/app.rs
@@ -84,6 +84,8 @@ impl EthUIApp {
                 ethui_networks::commands::networks_update,
                 ethui_networks::commands::networks_remove,
                 ethui_networks::commands::networks_is_dev,
+                ethui_networks::commands::networks_anvil_snapshot,
+                ethui_networks::commands::networks_anvil_revert,
                 ethui_networks::commands::networks_chain_id_from_provider,
                 ethui_db::commands::db_get_contracts,
                 ethui_db::commands::db_get_newer_transactions,

--- a/crates/networks/src/commands.rs
+++ b/crates/networks/src/commands.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::U256;
 use ethui_types::{NewNetworkParams, prelude::*};
 
 use crate::actor::{NetworksActorExt as _, networks};
@@ -42,6 +43,26 @@ pub async fn networks_is_dev(id: NetworkId) -> TauriResult<bool> {
         .with_context(|| "Network not found")?;
 
     Ok(network.is_dev().await?)
+}
+
+#[tauri::command]
+pub async fn networks_anvil_snapshot(id: NetworkId) -> TauriResult<U256> {
+    let network = networks()
+        .get(id)
+        .await?
+        .with_context(|| "Network not found")?;
+
+    Ok(network.anvil_snapshot().await?)
+}
+
+#[tauri::command]
+pub async fn networks_anvil_revert(id: NetworkId, snapshot_id: U256) -> TauriResult<bool> {
+    let network = networks()
+        .get(id)
+        .await?
+        .with_context(|| "Network not found")?;
+
+    Ok(network.anvil_revert(snapshot_id).await?)
 }
 
 #[tauri::command]

--- a/crates/networks/src/commands.rs
+++ b/crates/networks/src/commands.rs
@@ -1,7 +1,13 @@
-use alloy::primitives::U256;
-use ethui_types::{NewNetworkParams, prelude::*};
+use ethui_types::{AnvilSnapshot, AnvilSnapshotsState, NewNetworkParams, prelude::*};
 
 use crate::actor::{NetworksActorExt as _, networks};
+
+fn anvil_state(network: &Network) -> AnvilSnapshotsState {
+    AnvilSnapshotsState {
+        snapshots: network.anvil_snapshots.clone(),
+        current: network.current_snapshot,
+    }
+}
 
 #[tauri::command]
 pub async fn networks_get_current() -> TauriResult<Network> {
@@ -46,23 +52,101 @@ pub async fn networks_is_dev(id: NetworkId) -> TauriResult<bool> {
 }
 
 #[tauri::command]
-pub async fn networks_anvil_snapshot(id: NetworkId) -> TauriResult<U256> {
-    let network = networks()
+pub async fn networks_anvil_snapshot(id: NetworkId) -> TauriResult<AnvilSnapshotsState> {
+    let mut network = networks()
         .get(id)
         .await?
         .with_context(|| "Network not found")?;
 
-    Ok(network.anvil_snapshot().await?)
+    let snapshot_id = network.anvil_snapshot().await?;
+    let taken_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+
+    network.anvil_snapshots.push(AnvilSnapshot {
+        id: snapshot_id,
+        taken_at,
+    });
+    network.current_snapshot = Some(snapshot_id);
+
+    let name = network.name.clone();
+    let result = anvil_state(&network);
+    networks().update(name, network).await?;
+
+    Ok(result)
 }
 
 #[tauri::command]
-pub async fn networks_anvil_revert(id: NetworkId, snapshot_id: U256) -> TauriResult<bool> {
-    let network = networks()
+pub async fn networks_anvil_revert(
+    id: NetworkId,
+    snapshot_id: U256,
+) -> TauriResult<AnvilSnapshotsState> {
+    let mut network = networks()
         .get(id)
         .await?
         .with_context(|| "Network not found")?;
 
-    Ok(network.anvil_revert(snapshot_id).await?)
+    let reverted = network.anvil_revert(snapshot_id).await?;
+    if !reverted {
+        return Ok(anvil_state(&network));
+    }
+
+    // anvil consumes the reverted snapshot and invalidates any taken after it
+    if let Some(pos) = network
+        .anvil_snapshots
+        .iter()
+        .position(|s| s.id == snapshot_id)
+    {
+        network.anvil_snapshots.truncate(pos);
+    }
+    network.current_snapshot = None;
+
+    let name = network.name.clone();
+    let result = anvil_state(&network);
+    networks().update(name, network).await?;
+
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn networks_anvil_delete_snapshot(
+    id: NetworkId,
+    snapshot_id: U256,
+) -> TauriResult<AnvilSnapshotsState> {
+    let mut network = networks()
+        .get(id)
+        .await?
+        .with_context(|| "Network not found")?;
+
+    network.anvil_snapshots.retain(|s| s.id != snapshot_id);
+    if network.current_snapshot == Some(snapshot_id) {
+        network.current_snapshot = None;
+    }
+
+    let name = network.name.clone();
+    let result = anvil_state(&network);
+    networks().update(name, network).await?;
+
+    Ok(result)
+}
+
+#[tauri::command]
+pub async fn networks_anvil_reset(id: NetworkId) -> TauriResult<AnvilSnapshotsState> {
+    let mut network = networks()
+        .get(id)
+        .await?
+        .with_context(|| "Network not found")?;
+
+    network.anvil_reset().await?;
+    network.anvil_snapshots.clear();
+    network.current_snapshot = None;
+
+    let name = network.name.clone();
+    let result = anvil_state(&network);
+    networks().update(name, network).await?;
+
+    Ok(result)
 }
 
 #[tauri::command]

--- a/crates/networks/src/migrations.rs
+++ b/crates/networks/src/migrations.rs
@@ -156,6 +156,8 @@ fn migrate_networks_from_v2_to_v3(
                     decimals: network.decimals,
                     status: NetworkStatus::Unknown,
                     is_stack: false,
+                    anvil_snapshots: vec![],
+                    current_snapshot: None,
                 },
             )
         })

--- a/crates/sync/devnet/src/bin/devnet-sync-test.rs
+++ b/crates/sync/devnet/src/bin/devnet-sync-test.rs
@@ -78,6 +78,8 @@ async fn main() -> Result<()> {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: false,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
 
     // Create worker

--- a/crates/sync/devnet/src/tests/anvil_tests.rs
+++ b/crates/sync/devnet/src/tests/anvil_tests.rs
@@ -46,6 +46,8 @@ async fn test_http_worker_lifecycle() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
     let worker = AnvilHttp::new(network);
     let consumer = TestConsumer;
@@ -81,6 +83,8 @@ async fn test_ws_worker_lifecycle() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
     let worker = AnvilWs::new(network);
     let consumer = TestConsumer;
@@ -116,6 +120,8 @@ async fn test_message_processing_lifecycle() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: false,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
     let worker = AnvilHttp::new(network);
     let message_count = Arc::new(AtomicU32::new(0));
@@ -161,6 +167,8 @@ async fn test_wait_behavior() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
 
     // Test HTTP worker - should timeout or error without anvil
@@ -205,6 +213,8 @@ async fn test_wait_unavailable_node() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
 
     // Test HTTP worker failure
@@ -245,6 +255,8 @@ async fn test_block_subscription_behavior() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
 
     // Test HTTP block subscription - should fail gracefully without anvil
@@ -281,6 +293,8 @@ async fn test_worker_subscription_lifecycle() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
     let worker = Worker::new(AnvilHttp::new(network.clone()));
     let consumer = TestConsumer;
@@ -322,6 +336,8 @@ async fn test_historical_blocks_stream_interface() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
 
     // Test that backfill_blocks interface works without requiring actual anvil
@@ -368,6 +384,8 @@ async fn test_worker_streaming_lifecycle() {
         decimals: 18,
         status: NetworkStatus::Unknown,
         is_stack: true,
+        anvil_snapshots: vec![],
+        current_snapshot: None,
     };
 
     let worker = Worker::new(AnvilHttp::new(network.clone()));

--- a/crates/sync/devnet/src/tracker/mod.rs
+++ b/crates/sync/devnet/src/tracker/mod.rs
@@ -83,6 +83,8 @@ mod tests {
             decimals: 18,
             status: NetworkStatus::Unknown,
             is_stack: true,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         }
     }
 
@@ -260,6 +262,8 @@ mod tests {
             decimals: 18,
             status: NetworkStatus::Unknown,
             is_stack: true,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         };
 
         let worker = create_worker(ws_network.clone());
@@ -282,6 +286,8 @@ mod tests {
             decimals: 18,
             status: NetworkStatus::Unknown,
             is_stack: true,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         };
 
         let worker = create_worker(http_network.clone());

--- a/crates/sync/devnet/src/tracker/worker.rs
+++ b/crates/sync/devnet/src/tracker/worker.rs
@@ -304,6 +304,8 @@ mod tests {
             decimals: 18,
             status: NetworkStatus::Unknown,
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         };
 
         let worker = super::create_worker(network_with_ws.clone());
@@ -326,6 +328,8 @@ mod tests {
             decimals: 18,
             status: NetworkStatus::Unknown,
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         };
 
         let worker = super::create_worker(network_without_ws);
@@ -377,6 +381,8 @@ mod tests {
             decimals: 18,
             status: NetworkStatus::Unknown,
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         };
 
         let mut worker = Worker::new(AnvilHttp::new(network));
@@ -437,6 +443,8 @@ mod tests {
             decimals: 18,
             status: ethui_types::NetworkStatus::Unknown,
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         };
 
         let provider = AnvilWs::new(network);

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -16,7 +16,7 @@ pub use contracts::{Contract, ContractWithAbi};
 pub use error::{SerializableError, TauriResult};
 pub use events::Event;
 pub use global_state::GlobalState;
-pub use network::{Network, NetworkId, NetworkStatus};
+pub use network::{AnvilSnapshot, AnvilSnapshotsState, Network, NetworkId, NetworkStatus};
 pub use new_network_params::NewNetworkParams;
 pub use tokens::{
     Erc721Collection, Erc721Token, Erc721TokenData, Erc721TokenDetails, Erc1155Token,

--- a/crates/types/src/network/mod.rs
+++ b/crates/types/src/network/mod.rs
@@ -2,6 +2,7 @@ mod id;
 
 use alloy::{
     network::Ethereum,
+    primitives::U256,
     providers::{Provider, ProviderBuilder, RootProvider},
     rpc::{
         client::ClientBuilder,
@@ -136,6 +137,24 @@ impl Network {
             .request::<(), Metadata>("hardhat_metadata", ())
             .await?
             .forked_network)
+    }
+
+    pub async fn anvil_snapshot(&self) -> color_eyre::Result<U256> {
+        let provider = self.get_alloy_provider().await?;
+
+        Ok(provider
+            .client()
+            .request::<(), U256>("anvil_snapshot", ())
+            .await?)
+    }
+
+    pub async fn anvil_revert(&self, snapshot_id: U256) -> color_eyre::Result<bool> {
+        let provider = self.get_alloy_provider().await?;
+
+        Ok(provider
+            .client()
+            .request::<(U256,), bool>("anvil_revert", (snapshot_id,))
+            .await?)
     }
 
     pub async fn get_alloy_provider(&self) -> color_eyre::Result<RootProvider<Ethereum>> {

--- a/crates/types/src/network/mod.rs
+++ b/crates/types/src/network/mod.rs
@@ -35,6 +35,26 @@ pub struct Network {
 
     #[serde(default)]
     pub is_stack: bool,
+
+    #[serde(default)]
+    pub anvil_snapshots: Vec<AnvilSnapshot>,
+
+    // best-effort: set when a snapshot is taken or reverted to; not tracked across other
+    // state-changing RPC calls (txs, mining, etc), so treat as a hint rather than ground truth
+    #[serde(default)]
+    pub current_snapshot: Option<U256>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AnvilSnapshot {
+    pub id: U256,
+    pub taken_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnvilSnapshotsState {
+    pub snapshots: Vec<AnvilSnapshot>,
+    pub current: Option<U256>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
@@ -58,6 +78,8 @@ impl Network {
             decimals: 18,
             status: Default::default(),
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         }
     }
 
@@ -72,6 +94,8 @@ impl Network {
             decimals: 18,
             status: Default::default(),
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         }
     }
 
@@ -86,6 +110,8 @@ impl Network {
             decimals: 18,
             status: Default::default(),
             is_stack: false,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         }
     }
 
@@ -155,6 +181,17 @@ impl Network {
             .client()
             .request::<(U256,), bool>("anvil_revert", (snapshot_id,))
             .await?)
+    }
+
+    pub async fn anvil_reset(&self) -> color_eyre::Result<()> {
+        let provider = self.get_alloy_provider().await?;
+
+        provider
+            .client()
+            .request::<(), serde_json::Value>("anvil_reset", ())
+            .await?;
+
+        Ok(())
     }
 
     pub async fn get_alloy_provider(&self) -> color_eyre::Result<RootProvider<Ethereum>> {

--- a/crates/types/src/new_network_params.rs
+++ b/crates/types/src/new_network_params.rs
@@ -27,6 +27,8 @@ impl NewNetworkParams {
             decimals: self.decimals,
             status: NetworkStatus::Unknown,
             is_stack: self.is_stack,
+            anvil_snapshots: vec![],
+            current_snapshot: None,
         }
     }
 }

--- a/gui/src/routes/home/_l/networks/_l/$name.edit.tsx
+++ b/gui/src/routes/home/_l/networks/_l/$name.edit.tsx
@@ -1,3 +1,4 @@
+import type { AnvilSnapshotsState, Network } from "@ethui/types/network";
 import { type NetworkInputs, networkSchema } from "@ethui/types/network";
 import { Form } from "@ethui/ui/components/form";
 import { Button } from "@ethui/ui/components/shadcn/button";
@@ -22,7 +23,7 @@ export const Route = createFileRoute("/home/_l/networks/_l/$name/edit")({
   },
 });
 
-function Content({ network }: { network: NetworkInputs }) {
+function Content({ network }: { network: Network }) {
   const form = useForm({
     mode: "onBlur",
     resolver: zodResolver(networkSchema),
@@ -50,15 +51,19 @@ function Content({ network }: { network: NetworkInputs }) {
   };
 
   const isAnvil = network.id.chain_id === 31337;
-  const [snapshotId, setSnapshotId] = useState<string>();
+  const [anvilState, setAnvilState] = useState<AnvilSnapshotsState>({
+    snapshots: network.anvil_snapshots ?? [],
+    current: network.current_snapshot ?? null,
+  });
 
   const snapshot = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     try {
-      const id = await invoke<string>("networks_anvil_snapshot", {
-        id: network.id,
-      });
-      setSnapshotId(id);
+      const updated = await invoke<AnvilSnapshotsState>(
+        "networks_anvil_snapshot",
+        { id: network.id },
+      );
+      setAnvilState(updated);
       toast({ title: "Snapshot taken" });
     } catch (err: any) {
       toast({
@@ -69,15 +74,54 @@ function Content({ network }: { network: NetworkInputs }) {
     }
   };
 
-  const revert = async (e: React.MouseEvent<HTMLButtonElement>) => {
+  const revert =
+    (snapshotId: string) => async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      try {
+        const updated = await invoke<AnvilSnapshotsState>(
+          "networks_anvil_revert",
+          { id: network.id, snapshotId },
+        );
+        setAnvilState(updated);
+        toast({ title: "Reverted to snapshot" });
+      } catch (err: any) {
+        toast({
+          title: "Error",
+          description: err.toString(),
+          variant: "destructive",
+        });
+      }
+    };
+
+  const deleteSnapshot =
+    (snapshotId: string) => async (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      try {
+        const updated = await invoke<AnvilSnapshotsState>(
+          "networks_anvil_delete_snapshot",
+          { id: network.id, snapshotId },
+        );
+        setAnvilState(updated);
+      } catch (err: any) {
+        toast({
+          title: "Error",
+          description: err.toString(),
+          variant: "destructive",
+        });
+      }
+    };
+
+  const reset = async (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (!snapshotId) return;
     try {
-      await invoke("networks_anvil_revert", {
-        id: network.id,
-        snapshotId,
-      });
-      toast({ title: "Reverted to snapshot" });
+      const updated = await invoke<AnvilSnapshotsState>(
+        "networks_anvil_reset",
+        {
+          id: network.id,
+        },
+      );
+      setAnvilState(updated);
+      toast({ title: "Anvil reset" });
     } catch (err: any) {
       toast({
         title: "Error",
@@ -124,13 +168,38 @@ function Content({ network }: { network: NetworkInputs }) {
       </div>
 
       {isAnvil && (
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={snapshot}>
-            Snapshot
-          </Button>
-          <Button variant="outline" onClick={revert} disabled={!snapshotId}>
-            Revert
-          </Button>
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={snapshot}>
+              Take snapshot
+            </Button>
+            <Button variant="outline" onClick={reset}>
+              Reset anvil
+            </Button>
+          </div>
+
+          {anvilState.snapshots.length > 0 && (
+            <ul className="flex flex-col gap-1">
+              {anvilState.snapshots.map((s) => (
+                <li key={s.id} className="flex items-center gap-2">
+                  <span className="text-sm">
+                    #{s.id} — {new Date(s.taken_at).toLocaleString()}
+                    {anvilState.current === s.id && " (current)"}
+                  </span>
+                  <Button variant="outline" size="sm" onClick={revert(s.id)}>
+                    Revert
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={deleteSnapshot(s.id)}
+                  >
+                    Delete
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          )}
         </div>
       )}
 

--- a/gui/src/routes/home/_l/networks/_l/$name.edit.tsx
+++ b/gui/src/routes/home/_l/networks/_l/$name.edit.tsx
@@ -5,6 +5,7 @@ import { toast } from "@ethui/ui/hooks/use-toast";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createFileRoute, useRouter } from "@tanstack/react-router";
 import { invoke } from "@tauri-apps/api/core";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useNetworks } from "#/store/useNetworks";
 
@@ -48,6 +49,44 @@ function Content({ network }: { network: NetworkInputs }) {
     router.history.back();
   };
 
+  const isAnvil = network.id.chain_id === 31337;
+  const [snapshotId, setSnapshotId] = useState<string>();
+
+  const snapshot = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    try {
+      const id = await invoke<string>("networks_anvil_snapshot", {
+        id: network.id,
+      });
+      setSnapshotId(id);
+      toast({ title: "Snapshot taken" });
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.toString(),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const revert = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    if (!snapshotId) return;
+    try {
+      await invoke("networks_anvil_revert", {
+        id: network.id,
+        snapshotId,
+      });
+      toast({ title: "Reverted to snapshot" });
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.toString(),
+        variant: "destructive",
+      });
+    }
+  };
+
   // TODO: fix remove button
   return (
     <Form form={form} onSubmit={create} className="gap-4">
@@ -83,6 +122,17 @@ function Content({ network }: { network: NetworkInputs }) {
         <Form.Text label="Currency" name="currency" />
         <Form.NumberField label="Decimals" name="decimals" />
       </div>
+
+      {isAnvil && (
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={snapshot}>
+            Snapshot
+          </Button>
+          <Button variant="outline" onClick={revert} disabled={!snapshotId}>
+            Revert
+          </Button>
+        </div>
+      )}
 
       <div className="flex gap-2">
         <Button variant="destructive" onClick={remove}>

--- a/packages/types/network.ts
+++ b/packages/types/network.ts
@@ -18,9 +18,22 @@ export const networkSchema = z.object({
 
 export type NetworkInputs = z.infer<typeof networkSchema>;
 export type NetworkId = z.infer<typeof networkIdSchema>;
+
+export interface AnvilSnapshot {
+  id: string;
+  taken_at: number;
+}
+
 export type Network = NetworkInputs & {
   status: "unknown" | "online" | "offline";
+  anvil_snapshots: AnvilSnapshot[];
+  current_snapshot: string | null;
 };
+
+export interface AnvilSnapshotsState {
+  snapshots: AnvilSnapshot[];
+  current: string | null;
+}
 
 export const stacksSchema = z.object({ slug: z.string() });
 export type StacksInputs = z.infer<typeof stacksSchema>;


### PR DESCRIPTION
Closes #276 

## Summary

Adds the ability to take an anvil snapshot and revert to it later, directly from the network edit screen. Useful for repeatedly testing the same UI flow (e.g. a transaction confirmation) without having to manually re-prepare on-chain state each time.

- `Network::anvil_snapshot()` / `Network::anvil_revert(id)` (`crates/types/src/network/mod.rs`) call the `anvil_snapshot` / `anvil_revert` JSON-RPC methods on the network's provider, following the same `client().request(...)` pattern already used by `get_forked_network`/`is_dev` (`hardhat_metadata`).
- Two new Tauri commands, `networks_anvil_snapshot` and `networks_anvil_revert` (`crates/networks/src/commands.rs`), registered in `bin/src/app.rs`.
- Snapshot/Revert buttons on the network edit page (`gui/src/routes/home/_l/networks/_l/$name.edit.tsx`), shown only when the network's chain id is `31337` (anvil). Snapshot stores the returned id in local state; Revert is disabled until a snapshot has been taken.
