### PR TITLE
fix: query RPC live for native balance on unsynced chains

### DIFF
--- a/crates/sync/src/commands.rs
+++ b/crates/sync/src/commands.rs
@@ -19,14 +19,17 @@ pub async fn sync_get_native_balance(
     ) -> color_eyre::Result<U256> {
         let network = ethui_networks::get_network(chain_id).await?;
 
-        // TODO: check with networks if this is anvil or not
-        if network.is_dev().await? {
+        // The DB is only kept current for alchemy-synced chains. For those (and
+        // when not a dev node), serve the cached value. Otherwise — dev nodes, or
+        // any chain nothing background-syncs (e.g. Avalanche C-Chain) — query the
+        // network RPC live, or the balance would always read as 0.
+        if ethui_sync_alchemy::supports_network(chain_id) && !network.is_dev().await? {
+            Ok(db.get_native_balance(chain_id, address).await)
+        } else {
             Ok(
                 ethui_sync_devnet::get_native_balance(network.http_url.to_string(), address)
                     .await?,
             )
-        } else {
-            Ok(db.get_native_balance(chain_id, address).await)
         }
     }
 


### PR DESCRIPTION
## Problem
`sync_get_native_balance`'s non-dev branch only read the local DB cache. That cache is populated **only** for alchemy-synced chains. Any other chain with a working RPC (e.g. Avalanche C-Chain) always displayed `0` native balance, even though its RPC returned the correct value.

## Fix
Read the DB only when alchemy actually syncs the chain (`supports_network && !is_dev`); otherwise query the network RPC directly — same generic `provider.get_balance` the dev-node path already uses.

## Effect
- Native balance now correct for any chain with a working RPC (Avalanche, BNB, custom/private RPCs).
- Alchemy-synced chains keep their cached path unchanged.
- Native-balance only; erc20/history on unlisted chains still need alchemy support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)