### PR TITLE
feat: add Avalanche C-Chain to alchemy sync networks

### DIFF
--- a/crates/sync/alchemy/src/networks.rs
+++ b/crates/sync/alchemy/src/networks.rs
@@ -125,6 +125,14 @@ pub static NETWORKS: Lazy<HashMap<u64, Network>> = Lazy::new(|| {
         },
     );
 
+    map.insert(
+        43114,
+        Network {
+            base_url: Url::parse("https://avax-mainnet.g.alchemy.com").unwrap(),
+            default_from_block: 1,
+        },
+    );
+
     map
 });
 


### PR DESCRIPTION
## Summary
Adds Avalanche mainnet (chain 43114) to the alchemy sync `NETWORKS` map, enabling full alchemy sync — native balance, erc20 balances/metadata, and transfers — instead of it being an unsupported chain.

`base_url` is Alchemy's `avax-mainnet` host; `default_from_block: 1` matches the other entries (bump to a recent block later if transfer syncs are slow).

## Related
Complements #1585 (live-RPC native-balance fallback). That PR fixes native balance for *any* unsynced chain; this PR gives Avalanche the full synced experience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)