### PR TITLE
fix: allow dedup_id 0 so networks can be saved

### DIFF
--- a/packages/types/network.ts
+++ b/packages/types/network.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const networkIdSchema = z.object({
   chain_id: z.number("Invalid number").positive(),
-  dedup_id: z.number().positive().optional(),
+  dedup_id: z.number().nonnegative().optional(),
 });
 
 export const networkSchema = z.object({


### PR DESCRIPTION
## Problem
Editing a network (e.g. adding a WebSocket URL) silently failed to save.

`networkIdSchema` required `dedup_id` to be `.positive()`, but the default — and most common — `dedup_id` is `0` (assigned to the first network of any chain_id by the backend). The edit form loads existing networks with `id.dedup_id = 0`, so zod validation failed and react-hook-form blocked submit with no visible error.

## Fix
`dedup_id` is a 0-based dedup index; `0` is valid. Change `.positive()` → `.nonnegative()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)