### PR TITLE
fix(token-list): send User-Agent and check HTTP status in build script

### DIFF
--- a/crates/token-list/build.rs
+++ b/crates/token-list/build.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 const FILE: &str = "../../packages/data/gen/tokens.json";
 const URI: &str = "https://tokens.1inch.eth.link/";
 
+const USER_AGENT: &str = concat!("ethui-token-list/", env!("CARGO_PKG_VERSION"));
+
 const CHAIN_ID_WHITELIST: [i32; 3] = [1, 137, 10];
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -56,7 +58,12 @@ fn should_update() -> Result<bool> {
 }
 
 fn update() -> Result<()> {
-    let tokens: Vec<Token> = blocking::get(URI)?
+    let client = blocking::Client::builder().user_agent(USER_AGENT).build()?;
+
+    let tokens: Vec<Token> = client
+        .get(URI)
+        .send()?
+        .error_for_status()?
         .json::<TokenList>()?
         .tokens
         .into_iter()


### PR DESCRIPTION
## Problem

`cargo build` fails in `ethui-token-list` with a misleading JSON error:

```
error: failed to run custom build command for `ethui-token-list v1.27.0`
thread 'main' panicked at crates/token-list/build.rs:29:18:
Failed to create json: error decoding response body

Caused by:
    EOF while parsing a value at line 1 column 0
```

## Cause

The build script fetches the token list from `https://tokens.1inch.eth.link/`, served by the eth.limo IPFS gateway. That gateway now returns **403 with an empty body** to requests that send no `User-Agent` header.

reqwest sets no default `User-Agent`, and `.json()` does not check the status code — so the empty 403 body surfaced as a JSON parse failure rather than an HTTP error.

Reproduces directly:

```
$ curl -A "" -o /dev/null -w "code:%{http_code} size:%{size_download}\n" https://tokens.1inch.eth.link/
code:403 size:0

$ curl -o /dev/null -w "code:%{http_code} size:%{size_download}\n" https://tokens.1inch.eth.link/
code:200 size:575168
```

## Fix

- Build a blocking client with an explicit `User-Agent`.
- Call `.error_for_status()` before `.json()`, so any future gateway failure reports the real HTTP status instead of a bogus parse error.

## Why this hasn't hit everyone yet

`packages/data/gen/tokens.json` is committed, so a fresh clone gives the file a current mtime and `should_update()` skips the network call entirely. Nix builds skip it too via `NIX_BUILD`, and cargo caches build script runs.

Only a long-lived checkout whose `tokens.json` has aged past the 30-day window — combined with an invalidated build script cache — triggers the fetch. That combination gets more common over time as every checkout's committed `tokens.json` ages out, so this would eventually break clean rebuilds for everyone.

## Testing

`cargo build -p ethui-token-list` succeeds and regenerates `packages/data/gen/tokens.json` (content identical to the committed version, so no diff).