### PR TITLE
Skip chain add dialog in fast mode

### DIFF
--- a/crates/rpc/src/methods/chain_add.rs
+++ b/crates/rpc/src/methods/chain_add.rs
@@ -1,6 +1,7 @@
 use ethui_connections::Ctx;
 use ethui_dialogs::{Dialog, DialogMsg};
 use ethui_networks::{NetworksActorExt as _, networks};
+use ethui_settings::{SettingsActorExt as _, settings};
 use ethui_types::{Json, NewNetworkParams, U64};
 use jsonrpc_core::Params as RpcParams;
 use serde::{Deserialize, Serialize};
@@ -43,6 +44,11 @@ impl Method for ChainAdd {
             return Ok(Json::Null);
         }
 
+        if should_skip_dialog(&network).await {
+            networks().add(network).await?;
+            return Ok(Json::Null);
+        }
+
         let dialog = Dialog::new("chain-add", serde_json::to_value(&network)?);
         dialog.open().await?;
 
@@ -61,6 +67,22 @@ impl Method for ChainAdd {
 
         Ok(Json::Null)
     }
+}
+
+pub(super) async fn should_skip_dialog(network: &NewNetworkParams) -> bool {
+    let fast_mode = settings()
+        .get_all()
+        .await
+        .map(|settings| settings.fast_mode)
+        .unwrap_or(false);
+
+    fast_mode
+        && network
+            .clone()
+            .into_network(0)
+            .is_dev()
+            .await
+            .unwrap_or(false)
 }
 
 impl ChainAdd {

--- a/crates/rpc/src/methods/chain_update.rs
+++ b/crates/rpc/src/methods/chain_update.rs
@@ -6,7 +6,7 @@ use jsonrpc_core::Params as RpcParams;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use super::chain_add::Currency;
+use super::chain_add::{Currency, should_skip_dialog};
 use crate::{Error, Result, methods::Method, params::extract_single_param, utils};
 
 #[derive(Debug, Serialize)]
@@ -39,18 +39,23 @@ impl Method for ChainUpdate {
         }
 
         if !self.already_exists(&network).await? {
-            let add_dialog = Dialog::new("chain-add", serde_json::to_value(&new_network_params)?);
-            add_dialog.open().await?;
+            if should_skip_dialog(&new_network_params).await {
+                networks().add(new_network_params.clone()).await?;
+            } else {
+                let add_dialog =
+                    Dialog::new("chain-add", serde_json::to_value(&new_network_params)?);
+                add_dialog.open().await?;
 
-            while let Some(msg) = add_dialog.recv().await {
-                match msg {
-                    DialogMsg::Data(msg) => {
-                        if let Some("accept") = msg.as_str() {
-                            networks().add(new_network_params.clone()).await?;
-                            break;
+                while let Some(msg) = add_dialog.recv().await {
+                    match msg {
+                        DialogMsg::Data(msg) => {
+                            if let Some("accept") = msg.as_str() {
+                                networks().add(new_network_params.clone()).await?;
+                                break;
+                            }
                         }
+                        DialogMsg::Close => return Err(Error::UserRejectedDialog),
                     }
-                    DialogMsg::Close => return Err(Error::UserRejectedDialog),
                 }
             }
         }


### PR DESCRIPTION
## Summary
- skip wallet_addEthereumChain approval dialog for dev networks when fast mode is enabled
- apply the same chain-add skip path inside wallet_updateEthereumChain

## Validation
- cargo fmt
- cargo check -p ethui-rpc