### PR TITLE
fix(wallets): reject impersonator/real-key address collisions

### DIFF
--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -115,7 +115,7 @@ impl Wallets {
         let addresses = wallet.get_all_addresses().await;
 
         self.ensure_no_duplicates_of(&wallet.name())?;
-        self.ensure_no_impersonator_collision(&wallet, None).await?;
+        self.ensure_no_cross_tier_collision(&wallet, None).await?;
 
         self.wallets.push(wallet);
 
@@ -140,7 +140,7 @@ impl Wallets {
 
         let before = self.wallets[i].get_all_addresses().await;
         let updated = self.wallets[i].clone().update(params).await?;
-        self.ensure_no_impersonator_collision(&updated, Some(&name))
+        self.ensure_no_cross_tier_collision(&updated, Some(&name))
             .await?;
         self.wallets[i] = updated;
         let after = self.wallets[i].get_all_addresses().await;
@@ -254,17 +254,17 @@ impl Wallets {
         Ok(())
     }
 
-    /// Rejects `wallet` if it shares an address with an existing wallet of the
-    /// opposite signing kind (real-key vs. `Impersonator`) — otherwise an
-    /// impersonator could silently take over signing for a real wallet's
-    /// address just by becoming current. Same-kind collisions (e.g. one
-    /// mnemonic imported twice) are fine and stay allowed.
-    async fn ensure_no_impersonator_collision(
+    /// Rejects `wallet` if it shares an address with an existing wallet of a
+    /// different [`SecurityTier`] — otherwise a weaker-protected wallet could
+    /// silently take over signing for an address just by becoming current.
+    /// Same-tier collisions (e.g. one mnemonic imported twice) are fine and
+    /// stay allowed.
+    async fn ensure_no_cross_tier_collision(
         &self,
         wallet: &Wallet,
         exclude_name: Option<&str>,
     ) -> color_eyre::Result<()> {
-        let is_impersonator = matches!(wallet, Wallet::Impersonator(_));
+        let tier = SecurityTier::of(wallet);
         let addresses: HashSet<Address> = wallet
             .get_all_addresses()
             .await
@@ -277,17 +277,18 @@ impl Wallets {
                 continue;
             }
 
-            if matches!(other, Wallet::Impersonator(_)) == is_impersonator {
+            if SecurityTier::of(other) == tier {
                 continue;
             }
 
             for (_, address) in other.get_all_addresses().await {
                 if addresses.contains(&address) {
                     return Err(eyre!(
-                        "address {address} is already held by `{}` ({}) — an impersonator \
-                         cannot share an address with a real-key wallet",
+                        "address {address} is already held by `{}` ({}), which does not share \
+                         `{}`'s level of key protection — they cannot cover the same address",
                         other.name(),
-                        other.wallet_type()
+                        other.wallet_type(),
+                        wallet.wallet_type(),
                     ));
                 }
             }
@@ -297,12 +298,46 @@ impl Wallets {
     }
 }
 
+/// How well a wallet type protects the key material behind an address, from
+/// weakest to strongest. Two wallets covering the same address at different
+/// tiers is always a mistake, not a workflow: the weaker one either can't
+/// sign at all (`Impersonator`), or reintroduces a copy of the key at a
+/// lower protection level than the stronger wallet was chosen for — and
+/// `Wallets::find` has no notion of "the more secure one wins", so whichever
+/// answers first decides which protection level a signature actually goes
+/// through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecurityTier {
+    /// No key material at all.
+    None,
+    /// Key material stored unencrypted (`PlaintextWallet`'s mnemonic).
+    Unencrypted,
+    /// Key material encrypted at rest, external (a keystore file), or never
+    /// resident (hardware).
+    Protected,
+}
+
+impl SecurityTier {
+    fn of(wallet: &Wallet) -> Self {
+        match wallet {
+            Wallet::Impersonator(_) => Self::None,
+            Wallet::Plaintext(_) => Self::Unencrypted,
+            Wallet::HDWallet(_)
+            | Wallet::PrivateKey(_)
+            | Wallet::JsonKeystore(_)
+            | Wallet::Ledger(_) => Self::Protected,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr as _;
 
+    use ethui_types::prelude::json;
+
     use super::*;
-    use crate::wallets::{Impersonator, PlaintextWallet};
+    use crate::wallets::{Impersonator, PlaintextWallet, PrivateKeyWallet};
 
     /// The first address of the anvil mnemonic, which the default plaintext
     /// wallet derives.
@@ -316,23 +351,66 @@ mod tests {
         }
     }
 
+    fn impersonator(name: &str, addr: Address) -> Wallet {
+        Wallet::Impersonator(Impersonator {
+            name: name.into(),
+            addresses: vec![addr],
+            current: 0,
+        })
+    }
+
+    /// `LedgerWallet`'s fields are private, so build it the same way `create`
+    /// does: through its tagged `Deserialize` impl rather than a struct
+    /// literal.
+    fn ledger(name: &str, addr: Address) -> Wallet {
+        serde_json::from_value(json!({
+            "type": "ledger",
+            "name": name,
+            "addresses": [["0", addr]],
+            "current": 0,
+        }))
+        .unwrap()
+    }
+
+    /// Anvil's default private key, deriving `ANVIL_0` — routed through the
+    /// real `from_params`/encryption path rather than a struct literal.
+    async fn private_key_wallet(name: &str) -> Wallet {
+        let params = serde_json::from_value(json!({
+            "name": name,
+            "privateKey": "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+            "password": "test",
+        }))
+        .unwrap();
+
+        Wallet::PrivateKey(PrivateKeyWallet::from_params(params).await.unwrap())
+    }
+
     #[tokio::test]
-    async fn same_kind_collisions_are_allowed() {
+    async fn same_tier_collisions_are_allowed() {
         let addr = Address::from_str(ANVIL_0).unwrap();
-        let wallets = wallets_with(vec![Wallet::Impersonator(Impersonator {
-            name: "impersonator".into(),
-            addresses: vec![addr],
-            current: 0,
-        })]);
-        let second = Wallet::Impersonator(Impersonator {
-            name: "second-impersonator".into(),
-            addresses: vec![addr],
-            current: 0,
-        });
+        let wallets = wallets_with(vec![impersonator("impersonator", addr)]);
+        let second = impersonator("second-impersonator", addr);
 
         assert!(
             wallets
-                .ensure_no_impersonator_collision(&second, None)
+                .ensure_no_cross_tier_collision(&second, None)
+                .await
+                .is_ok()
+        );
+    }
+
+    /// Two `Protected`-tier wallets of different *types* are still the same
+    /// tier — an encrypted private key and a hardware wallet covering the
+    /// same address don't downgrade each other's protection.
+    #[tokio::test]
+    async fn different_protected_wallet_types_may_share_an_address() {
+        let addr = Address::from_str(ANVIL_0).unwrap();
+        let wallets = wallets_with(vec![ledger("ledger", addr)]);
+        let private_key = private_key_wallet("private-key").await;
+
+        assert!(
+            wallets
+                .ensure_no_cross_tier_collision(&private_key, None)
                 .await
                 .is_ok()
         );
@@ -342,14 +420,10 @@ mod tests {
     async fn an_impersonator_cannot_shadow_a_real_key_wallets_address() {
         let addr = Address::from_str(ANVIL_0).unwrap();
         let wallets = wallets_with(vec![Wallet::Plaintext(PlaintextWallet::default())]);
-        let shadow = Wallet::Impersonator(Impersonator {
-            name: "shadow".into(),
-            addresses: vec![addr],
-            current: 0,
-        });
+        let shadow = impersonator("shadow", addr);
 
         let err = wallets
-            .ensure_no_impersonator_collision(&shadow, None)
+            .ensure_no_cross_tier_collision(&shadow, None)
             .await
             .unwrap_err();
 
@@ -359,38 +433,57 @@ mod tests {
     #[tokio::test]
     async fn a_real_key_wallet_cannot_collide_with_an_existing_impersonator() {
         let addr = Address::from_str(ANVIL_0).unwrap();
-        let wallets = wallets_with(vec![Wallet::Impersonator(Impersonator {
-            name: "impersonator".into(),
-            addresses: vec![addr],
-            current: 0,
-        })]);
+        let wallets = wallets_with(vec![impersonator("impersonator", addr)]);
         let real_key = Wallet::Plaintext(PlaintextWallet::default());
 
         let err = wallets
-            .ensure_no_impersonator_collision(&real_key, None)
+            .ensure_no_cross_tier_collision(&real_key, None)
             .await
             .unwrap_err();
 
-        assert!(err.to_string().contains("impersonator"), "got: {err}");
+        assert!(err.to_string().contains("Impersonator"), "got: {err}");
+    }
+
+    /// A plaintext (unencrypted) mnemonic must not be allowed to cover an
+    /// address already backed by an encrypted/hardware wallet — that would
+    /// leave a copy of the key at a lower protection level than the user
+    /// chose for it.
+    #[tokio::test]
+    async fn a_plaintext_wallet_cannot_shadow_a_protected_wallets_address() {
+        let addr = Address::from_str(ANVIL_0).unwrap();
+        let wallets = wallets_with(vec![ledger("ledger", addr)]);
+        let plaintext = Wallet::Plaintext(PlaintextWallet::default());
+
+        let err = wallets
+            .ensure_no_cross_tier_collision(&plaintext, None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Ledger"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn a_protected_wallet_cannot_collide_with_an_existing_plaintext_wallet() {
+        let wallets = wallets_with(vec![Wallet::Plaintext(PlaintextWallet::default())]);
+        let private_key = private_key_wallet("private-key").await;
+
+        let err = wallets
+            .ensure_no_cross_tier_collision(&private_key, None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Plaintext"), "got: {err}");
     }
 
     #[tokio::test]
     async fn updating_a_wallet_excludes_its_own_prior_entry() {
         let addr = Address::from_str(ANVIL_0).unwrap();
-        let wallets = wallets_with(vec![Wallet::Impersonator(Impersonator {
-            name: "impersonator".into(),
-            addresses: vec![addr],
-            current: 0,
-        })]);
-        let unchanged = Wallet::Impersonator(Impersonator {
-            name: "impersonator".into(),
-            addresses: vec![addr],
-            current: 0,
-        });
+        let wallets = wallets_with(vec![impersonator("impersonator", addr)]);
+        let unchanged = impersonator("impersonator", addr);
 
         assert!(
             wallets
-                .ensure_no_impersonator_collision(&unchanged, Some("impersonator"))
+                .ensure_no_cross_tier_collision(&unchanged, Some("impersonator"))
                 .await
                 .is_ok()
         );

--- a/crates/wallets/src/lib.rs
+++ b/crates/wallets/src/lib.rs
@@ -115,8 +115,8 @@ impl Wallets {
         let addresses = wallet.get_all_addresses().await;
 
         self.ensure_no_duplicates_of(&wallet.name())?;
+        self.ensure_no_impersonator_collision(&wallet, None).await?;
 
-        // TODO: ensure no duplicates
         self.wallets.push(wallet);
 
         self.on_wallet_changed().await?;
@@ -139,7 +139,10 @@ impl Wallets {
             .with_context(|| format!("invalid wallet name `{name}`"))?;
 
         let before = self.wallets[i].get_all_addresses().await;
-        self.wallets[i] = self.wallets[i].clone().update(params).await?;
+        let updated = self.wallets[i].clone().update(params).await?;
+        self.ensure_no_impersonator_collision(&updated, Some(&name))
+            .await?;
+        self.wallets[i] = updated;
         let after = self.wallets[i].get_all_addresses().await;
 
         tokio::spawn(async move {
@@ -249,5 +252,147 @@ impl Wallets {
             return Err(eyre!("duplicate wallet names `{}`", name));
         }
         Ok(())
+    }
+
+    /// Rejects `wallet` if it shares an address with an existing wallet of the
+    /// opposite signing kind (real-key vs. `Impersonator`) — otherwise an
+    /// impersonator could silently take over signing for a real wallet's
+    /// address just by becoming current. Same-kind collisions (e.g. one
+    /// mnemonic imported twice) are fine and stay allowed.
+    async fn ensure_no_impersonator_collision(
+        &self,
+        wallet: &Wallet,
+        exclude_name: Option<&str>,
+    ) -> color_eyre::Result<()> {
+        let is_impersonator = matches!(wallet, Wallet::Impersonator(_));
+        let addresses: HashSet<Address> = wallet
+            .get_all_addresses()
+            .await
+            .into_iter()
+            .map(|(_, address)| address)
+            .collect();
+
+        for other in self.wallets.iter() {
+            if exclude_name == Some(other.name().as_str()) {
+                continue;
+            }
+
+            if matches!(other, Wallet::Impersonator(_)) == is_impersonator {
+                continue;
+            }
+
+            for (_, address) in other.get_all_addresses().await {
+                if addresses.contains(&address) {
+                    return Err(eyre!(
+                        "address {address} is already held by `{}` ({}) — an impersonator \
+                         cannot share an address with a real-key wallet",
+                        other.name(),
+                        other.wallet_type()
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr as _;
+
+    use super::*;
+    use crate::wallets::{Impersonator, PlaintextWallet};
+
+    /// The first address of the anvil mnemonic, which the default plaintext
+    /// wallet derives.
+    const ANVIL_0: &str = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+
+    fn wallets_with(entries: Vec<Wallet>) -> Wallets {
+        Wallets {
+            wallets: entries,
+            current: 0,
+            file: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn same_kind_collisions_are_allowed() {
+        let addr = Address::from_str(ANVIL_0).unwrap();
+        let wallets = wallets_with(vec![Wallet::Impersonator(Impersonator {
+            name: "impersonator".into(),
+            addresses: vec![addr],
+            current: 0,
+        })]);
+        let second = Wallet::Impersonator(Impersonator {
+            name: "second-impersonator".into(),
+            addresses: vec![addr],
+            current: 0,
+        });
+
+        assert!(
+            wallets
+                .ensure_no_impersonator_collision(&second, None)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn an_impersonator_cannot_shadow_a_real_key_wallets_address() {
+        let addr = Address::from_str(ANVIL_0).unwrap();
+        let wallets = wallets_with(vec![Wallet::Plaintext(PlaintextWallet::default())]);
+        let shadow = Wallet::Impersonator(Impersonator {
+            name: "shadow".into(),
+            addresses: vec![addr],
+            current: 0,
+        });
+
+        let err = wallets
+            .ensure_no_impersonator_collision(&shadow, None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("Plaintext"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn a_real_key_wallet_cannot_collide_with_an_existing_impersonator() {
+        let addr = Address::from_str(ANVIL_0).unwrap();
+        let wallets = wallets_with(vec![Wallet::Impersonator(Impersonator {
+            name: "impersonator".into(),
+            addresses: vec![addr],
+            current: 0,
+        })]);
+        let real_key = Wallet::Plaintext(PlaintextWallet::default());
+
+        let err = wallets
+            .ensure_no_impersonator_collision(&real_key, None)
+            .await
+            .unwrap_err();
+
+        assert!(err.to_string().contains("impersonator"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn updating_a_wallet_excludes_its_own_prior_entry() {
+        let addr = Address::from_str(ANVIL_0).unwrap();
+        let wallets = wallets_with(vec![Wallet::Impersonator(Impersonator {
+            name: "impersonator".into(),
+            addresses: vec![addr],
+            current: 0,
+        })]);
+        let unchanged = Wallet::Impersonator(Impersonator {
+            name: "impersonator".into(),
+            addresses: vec![addr],
+            current: 0,
+        });
+
+        assert!(
+            wallets
+                .ensure_no_impersonator_collision(&unchanged, Some("impersonator"))
+                .await
+                .is_ok()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Adding a wallet whose address already belongs to another wallet is currently unguarded (`ensure_no_duplicates_of` only checks names). When the colliding pair is a real-key wallet (mnemonic/HD/private key) and an `Impersonator`, `Wallets::find` has no tie-breaker and returns whichever comes first in the list — so an impersonator can silently shadow a real wallet's address. Since `Impersonator::build_signer` always errors, any transaction from that address then fails, even though the real key is right there.

## Fix

`create`/`update` now call `ensure_no_impersonator_collision`, which rejects the new/updated wallet if it shares an address with an existing wallet of the opposite signing kind. Same-kind collisions (e.g. the same mnemonic imported twice, or two impersonators) are unaffected and stay allowed.